### PR TITLE
Stagger post-processing by msec value to soften DB load spikes

### DIFF
--- a/www/lib/postprocess.php
+++ b/www/lib/postprocess.php
@@ -210,7 +210,7 @@ class PostProcess
 		// 1st process is not delayed, 2nd by stagger time, 3rd by 2x stagger, 4th 3x etc
                 if ($threads > 1)
                 {
-                	$stagger = 300000;
+                	$stagger = 200000;
                         usleep(($threads - 1) * $stagger);
                 }
 


### PR DESCRIPTION
Stagger post-processing by msec value to soften DB load spikes

Post-process #1 should not be delayed
pp #2 delayed by msec $stagger variable (200-400 works well on my hardware)
pp #3 delayed by $stagger value *2
pp #4 delayed by $stagger value *3
etc
