### PR TITLE
don't notify users if the email address is found in the database for password reset

### DIFF
--- a/www/pages/forgottenpassword.php
+++ b/www/pages/forgottenpassword.php
@@ -57,7 +57,7 @@ switch($action)
 			$ret = $users->getByEmail($_POST['email']);
 			if (!$ret)
 			{
-				$page->smarty->assign('error', "The email address is not recognised.");
+				$page->smarty->assign('sent', "true");
 				break;
 			}
 			else


### PR DESCRIPTION
this would prevent people from entering email addresses to see if an account is registered.
