### PR TITLE
Remove RSS logo filecheck

### DIFF
--- a/www/themes/Default/templates/frontend/rss.tpl
+++ b/www/themes/Default/templates/frontend/rss.tpl
@@ -9,7 +9,7 @@
 <webMaster>{$site->email} ({$site->title|escape})</webMaster>
 <category>{$site->meta_keywords}</category>
 <image>
-	<url>{if $site->style != "" && $site->style != "/" && $site->style != "Default" && file_exists('{$smarty.const.WWW_TOP}/themes/{$site->style}/images/logo.png')}{$smarty.const.WWW_TOP}/themes/{$site->style}/images/logo.png{else}{$smarty.const.WWW_TOP}/themes/Default/images/logo.png{/if}</url>
+	<url>{if $site->style != "" && $site->style != "/" && $site->style != "Default"}{$smarty.const.WWW_TOP}/themes/{$site->style}/images/logo.png{else}{$smarty.const.WWW_TOP}/themes/Default/images/logo.png{/if}</url>
 	<title>{$site->title|escape}</title>
 	<link>{$serverroot}</link>
 	<description>Visit {$site->title|escape} - {$site->strapline|escape}</description>


### PR DESCRIPTION
File was not working correctly. Will not be able to fallback to default
site logo if logo is missing from current template. Think $site_logo
needs to be defined in main php to work.

Update so logo will display still works.
