### PR TITLE
Major bug in escapeString causing all kinds of issues.

### DIFF
--- a/www/lib/framework/db.php
+++ b/www/lib/framework/db.php
@@ -31,20 +31,23 @@ class DB
 				exit();
 			}
 
-			DB::$mysqli->set_charset('utf8');
+			if (!DB::$mysqli->set_charset('utf8')) {
+				printf(DB::$mysqli->error);
+			} else {
+				DB::$mysqli->character_set_name();
+			}
+
 			DB::$initialized = true;
 		}
 	}
 
 	public function escapeString($str)
 	{
-		if (is_null($str))
-		{
+		if (is_null($str)){
 			return "NULL";
 		} else {
-		$str = preg_replace("/[\x80-\xff]/", " ", $str);
-		return "'".DB::$mysqli->real_escape_string($str)."'";
-	}
+			return "'".DB::$mysqli->real_escape_string($str)."'";
+		}	
 	}
 
 	public function makeLookupTable($rows, $keycol)


### PR DESCRIPTION
Fixed a major bug where characters were being stripped on everything using escape string, this was affecting almost everything on the site (even pictures inserted into the DB being corrupted by missing characters), if you added this and are reading(the stripping of characters) please add another function for whatever purpose it add instead of modifying this function.
