### PR TITLE
Minor Adjustment to Smarty Tag in Browse and tweak css to restore magnifying glass. 

### DIFF
--- a/www/pages/browse.php
+++ b/www/pages/browse.php
@@ -37,7 +37,7 @@ $page->smarty->assign('pagerquerysuffix', "#results");
 $pager = $page->smarty->fetch("pager.tpl");
 $page->smarty->assign('pager', $pager);
 
-$section = '';
+$covgroup = '';
 if ($category == -1 && $grp == "")
 	$page->smarty->assign("catname","All");			
 elseif ($category != -1 && $grp == "")
@@ -48,13 +48,13 @@ elseif ($category != -1 && $grp == "")
 	if ($cdata) {
 		$page->smarty->assign('catname',$cdata["title"]);
 		if ($cdata['parentID'] == Category::CAT_PARENT_GAME || $cdata['ID'] == Category::CAT_PARENT_GAME)
-			$section = 'console';
+			$covgroup = 'console';
 		elseif ($cdata['parentID'] == Category::CAT_PARENT_MOVIE || $cdata['ID'] == Category::CAT_PARENT_MOVIE)
-			$section = 'movies';
+			$covgroup = 'movies';
 		elseif ($cdata['parentID'] == Category::CAT_PARENT_MUSIC || $cdata['ID'] == Category::CAT_PARENT_MUSIC)
-			$section = 'music';
+			$covgroup = 'music';
 		elseif ($cdata['parentID'] == Category::CAT_PARENT_BOOKS || $cdata['ID'] == Category::CAT_PARENT_BOOKS)
-			$section = 'books';
+			$covgroup = 'books';
 	} else {
 		$page->show404();
 	}
@@ -63,7 +63,7 @@ elseif ($grp != "")
 {
 	$page->smarty->assign('catname',$grp);			
 }
-$page->smarty->assign('section',$section);
+$page->smarty->assign('covgroup',$covgroup);
 
 foreach($ordering as $ordertype) 
 	$page->smarty->assign('orderby'.$ordertype, WWW_TOP."/browse?t=".$category."&amp;g=".$grp."&amp;ob=".$ordertype."&amp;offset=0");	

--- a/www/themes/Default/templates/frontend/basepage.tpl
+++ b/www/themes/Default/templates/frontend/basepage.tpl
@@ -26,6 +26,7 @@
     <style>
     select { min-width: 120px ; width: auto; }
     input { width: 180px; }
+    .rarfilelist img { position: relative; display: inline; height: 16px; text-align: center; white-space: nowrap; width: 16px; opacity: 1; }
     </style>
 
     <!-- Site Icon files -->

--- a/www/themes/Default/templates/frontend/browse.tpl
+++ b/www/themes/Default/templates/frontend/browse.tpl
@@ -16,7 +16,7 @@
 <form id="nzb_multi_operations_form" action="get">
 
 <div class="nzb_multi_operations">
-	{if $section != ''}View: <a href="{$smarty.const.WWW_TOP}/{$section}?t={$category}">Covers</a> | <b>List</b><br />{/if}
+	{if $covgroup != ''}View: <a href="{$smarty.const.WWW_TOP}/{$covgroup}?t={$category}">Covers</a> | <b>List</b><br />{/if}
 	<small>With Selected:</small>
 	<input type="button" class="nzb_multi_operations_download" value="Download NZBs" />
 	<input type="button" class="nzb_multi_operations_cart" value="Add to Cart" />


### PR DESCRIPTION
Smarty uses $section be default in its templating structure and this could cause issues going forward. 
Replased it with covgroup as the only time I have found this being used was when assigning those categories that had cover views. 

Also added minor css style to basepage to return the opacity to the rarfilelist magnifying glass.
