### PR TITLE
Filter out duplicate menu items from top.

### DIFF
--- a/www/themes/Default/templates/frontend/mainmenu.tpl
+++ b/www/themes/Default/templates/frontend/mainmenu.tpl
@@ -5,6 +5,7 @@
 	{foreach from=$menulist item=menu}
 	{assign var="var" value=$menu.menueval}	
 	{eval var="$var," assign='menuevalresult'}
+	{if $menu.title == "Music" or $menu.title == "Movies" or $menu.title == "Console" or $menu.title == "Books" or $menu.title == "Login" or $menu.title == "Register" or $menu.title == "Profile" or $menu.title == "Groups List"}{continue}{/if}
 	{if $menuevalresult|replace:",":"1" == "1"}
 	<li class="mmenu{if $menu.newwindow =="1"}_new{/if}"><a {if $menu.newwindow =="1"}class="external" target="null"{/if} title="{$menu.tooltip}" href="{$menu.href}">{$menu.title}</a></li>
 	{/if}


### PR DESCRIPTION
Filtered out the following since they are in the header menu and the status menu on the top. 
"Music", "Movies", "Console", "Books", "Login", "Register", "Profile", "Groups List"
