### PR TITLE
If binarythreads is 1 don't set threads to 0

### DIFF
--- a/misc/update_scripts/threaded_scripts/binaries_safe_threaded.py
+++ b/misc/update_scripts/threaded_scripts/binaries_safe_threaded.py
@@ -51,7 +51,9 @@ cur = connect()
 cur[0].execute("SELECT (SELECT value FROM site WHERE setting = 'binarythreads') AS a, (SELECT value FROM site WHERE setting = 'maxmssgs') AS b, (SELECT value FROM site WHERE setting = 'hashcheck') AS c")
 dbgrab = cur[0].fetchall()
 disconnect(cur[0], cur[1])
-run_threads = int(dbgrab[0][0])-1
+thread_count = int(dbgrab[0][0])-1 
+run_threads = count if count > 0 else 1
+
 maxmssgs = int(dbgrab[0][1])
 hashcheck = int(dbgrab[0][2])
 


### PR DESCRIPTION
I'm not sure why we subtract one from the users configured number of threads, but if we need to do that for some reason, this is a potential fix for when the thread count is configured as 1...which is the default configuration.

I'm not sure how many other scripts subtract 1 from the 'binarythreads' setting.
