### PR TITLE
Adding path generation to .../tmux/.../tmux_mem_cpu_load.sh

### DIFF
--- a/misc/update_scripts/nix_scripts/tmux/powerline/powerline/segments/tmux_mem_cpu_load.sh
+++ b/misc/update_scripts/nix_scripts/tmux/powerline/powerline/segments/tmux_mem_cpu_load.sh
@@ -1,5 +1,5 @@
 # Print out Memory, cpu and load using https://github.com/thewtex/tmux-mem-cpu-load
-mem_app=bin/tmux-mem-cpu-load
+mem_app=$(php ../../../../nZEDbBase.php)/misc/update_scripts/nix_scripts/tmux/bin/tmux-mem-cpu-load
 run_segment() {
 type $mem_app >/dev/null 2>&1
 if [ "$?" -ne 0 ]; then


### PR DESCRIPTION
I noticed a FIXME in misc/update_scripts/nix_scripts/tmux/powerline/powerline/segments/uspsetting.sh for editing the path to config. I've extended it to all shell scripts to save myself some pain as nZEDb is not the name of my base install ;-)
If you want this I could probably do something similar for python scripts if needed.
