### PR TITLE
Fixed dot trimming bug

### DIFF
--- a/misc/update_scripts/python_scripts/nntpproxy.py
+++ b/misc/update_scripts/python_scripts/nntpproxy.py
@@ -95,7 +95,7 @@ class NNTPProxyRequestHandler(SocketServer.StreamRequestHandler):
 					self.wfile.write("220 %d %s\r\n" % (articleno, msgid))
 					head = "\r\n".join([": ".join(item) for item in head.items()]) + "\r\n\r\n"
 					self.wfile.write(head)
-					self.wfile.write(body)
+					self.wfile.write(body.replace("\r\n.", "\r\n..")
 					self.wfile.write(".\r\n")
 				elif data.startswith("HEAD"):
 					msgid = data.split(None, 1)[1]
@@ -108,7 +108,7 @@ class NNTPProxyRequestHandler(SocketServer.StreamRequestHandler):
 					msgid = data.split(None, 1)[1]
 					body = nntp_client.body(msgid)
 					self.wfile.write("222 %s\r\n" % (msgid))
-					self.wfile.write(body)
+					self.wfile.write(body.replace("\r\n.", "\r\n..")
 					self.wfile.write(".\r\n")
 				elif data.startswith("LIST OVERVIEW.FMT"):
 					fmt = nntp_client.list_overview_fmt()


### PR DESCRIPTION
This bug could cause body content to be terminated early if the
body contained a line which consisted of only ".\r\n" as the duplicated
'escaping' dot was being removed.
