### PR TITLE
Fixing Virtual Host configuration to match the wiki (which works)

### DIFF
--- a/Ubuntu 13.10 INSTALL GUIDE.txt
+++ b/Ubuntu 13.10 INSTALL GUIDE.txt
@@ -148,6 +148,7 @@ Most of this guide is done from the command line (terminal).
     	DocumentRoot "/var/www/nZEDb/www"
     	LogLevel warn
     	ServerSignature Off
+	ErrorLog /var/log/apache2/error.log
 
   <Directory "/var/www/nZEDb/www">
          Options FollowSymLinks


### PR DESCRIPTION
This works with 13.10 to address changes in apache2 configuration and match what works from the wiki. 
