### PR TITLE
Fix start.php to kill the correct named NNTPProxy tmux window session

### DIFF
--- a/misc/update_scripts/nix_scripts/tmux/start.php
+++ b/misc/update_scripts/nix_scripts/tmux/start.php
@@ -164,7 +164,7 @@ function start_apps($tmux_session)
 
 function window_proxy($tmux_session, $window)
 {
-	exec("tmux kill-session -t NNTPProxy");
+	exec("tmux kill-session -t nntpproxy");
 	$s = new Sites();
 	$site = $s->get();
 	$nntpproxy = $site->nntpproxy;


### PR DESCRIPTION
Makes the name for what to kill match up to the same name used to create it.
