### PR TITLE
Fixing use of continue when not in a loop.

### DIFF
--- a/www/lib/postprocess.php
+++ b/www/lib/postprocess.php
@@ -449,13 +449,13 @@ class PostProcess
 
 				// turn on output buffering
 				ob_start();
-				
+
 				// uncompress the nzb
 				@readgzfile($nzbpath);
-				
+
 				// read the nzb into memory
 				$nzbfile = ob_get_contents();
-				
+
 				// Clean (erase) the output buffer and turn off output buffering
 				ob_end_clean();
 
@@ -1315,25 +1315,26 @@ class PostProcess
 
 				// File is compressed, use unrar to get the content
 				$rarfile = $this->tmpPath.'rarfile'.mt_rand(0,99999).'.rar';
-				if(!@file_put_contents($rarfile, $fetchedBinary))
-					continue;
-				$execstring = '"'.$this->site->unrarpath.'" e -ai -ep -c- -id -inul -kb -or -p- -r -y "'.$rarfile.'" "'.$this->tmpPath.'"';
-				$output = runCmd($execstring, false, true);
-				if (isset($files[0]['name']))
+				if(@file_put_contents($rarfile, $fetchedBinary))
 				{
-					if ($this->echooutput)
-						echo 'r';
-					foreach ($files as $file)
+					$execstring = '"'.$this->site->unrarpath.'" e -ai -ep -c- -id -inul -kb -or -p- -r -y "'.$rarfile.'" "'.$this->tmpPath.'"';
+					$output = runCmd($execstring, false, true);
+					if (isset($files[0]['name']))
 					{
-						if (isset($file['name']))
+						if ($this->echooutput)
+							echo 'r';
+						foreach ($files as $file)
 						{
-							if (!isset($file['next_offset']))
-								$file['next_offset'] = 0;
-							$range = mt_rand(0,99999);
-							if (isset($file['range']))
-								$range = $file['range'];
+							if (isset($file['name']))
+							{
+								if (!isset($file['next_offset']))
+									$file['next_offset'] = 0;
+								$range = mt_rand(0,99999);
+								if (isset($file['range']))
+									$range = $file['range'];
 
-							$retval[] = array('name' => $file['name'], 'source' => $file['source'], 'range' => $range, 'size' => $file['size'], 'date' => $file['date'], 'pass' => $file['pass'], 'next_offset' => $file['next_offset']);
+								$retval[] = array('name' => $file['name'], 'source' => $file['source'], 'range' => $range, 'size' => $file['size'], 'date' => $file['date'], 'pass' => $file['pass'], 'next_offset' => $file['next_offset']);
+							}
 						}
 					}
 				}


### PR DESCRIPTION
Was supposed to be a simple fix, sorry for all the white-space that got caught up.
Main issue start at line 1319. This was presumably a loop previously and the continue got left behind during refactoring. Reversed the logic of the test and blocked the code to be executed to make it work as expected.
