### PR TITLE
Added "PDO::MYSQL_ATTR_LOCAL_INFILE => true" to MySQL connection options...

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -3,7 +3,9 @@ No pull requests will be accepted without this file being updated to reflect wha
 No pull requests will be accepted to any branch except the dev branch.
 Each update goes to the top of the file
 
-
+2014-01-10 -> ajoergensen -> added "PDO::MYSQL_ATTR_LOCAL_INFILE => true" to MySQL connection options. Needed for dump_predb.php remote. You also need to configure the MySQL server to allow
+                             loading loading files (see http://goo.gl/L4cUij - Basically you need local-infile=1 in my.cnf for both [mysql] and [mysqld] and make sure mysqld is not started  
+                             with --local-infile=0) 
 2014-01-09 -> bart39   -> fixed typo with requestid lookup in releases stage 5b
                           fixed typo's in namefixer
 2014-01-08 -> jonnyboy -> commented out auto disable backfill until I can find the cause, increased matches to headers, added regex to add yEnc headers that do not have it, but match the pattern

--- a/www/lib/framework/db.php
+++ b/www/lib/framework/db.php
@@ -98,7 +98,7 @@ class DB extends PDO
 
 		try
 		{
-			$options = array( PDO::ATTR_PERSISTENT => true, PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION, PDO::ATTR_TIMEOUT => 180);
+			$options = array( PDO::ATTR_PERSISTENT => true, PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION, PDO::ATTR_TIMEOUT => 180, PDO::MYSQL_ATTR_LOCAL_INFILE => true);
 			if ($this->dbsystem == 'mysql')
 			{
 				$options[PDO::MYSQL_ATTR_INIT_COMMAND] = "SET NAMES 'utf8'";


### PR DESCRIPTION
.... Needed for dump_predb.php remote. You also need to configure the MySQL server to allow loading loading files (see http://goo.gl/L4cUij - Basically you need local-infile=1 in my.cnf for both [mysql] and [mysqld] and make sure mysqld is not started with --local-infile=0)
