### PR TITLE
Added a number of new groups, based on current usenet posts.

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -6,6 +6,7 @@ Each update goes to the top of the file
 ***Please run runonce/relocateOldDirectoryContents.php to move all of your old files into the new folder names***
 
 
+2014-01-20 -> egandt   -> added a number of new groups, fixed logging in populate_anidb
 2014-01-20 -> jonnyboy -> changed button in browse.tpl
                           moved smarty path, please run sudo chmod -R 777 smarty/templates_c/
                           reverted change to predb, please run 'update predb set nfo = REPLACE(nfo, 'nzb.isasecret.com', 'www.newshost.co.za');'

--- a/db/mysql_patches/2014_01_20_1_groups.sql
+++ b/db/mysql_patches/2014_01_20_1_groups.sql
@@ -1,0 +1,16 @@
+INSERT IGNORE INTO `groups` (`name`, `minfilestoformrelease`, `minsizetoformrelease`, `description`) VALUES ('alt.binaries.multimedia.erotica.anime', 5, 31457280, 'erotica anime');
+INSERT IGNORE INTO `groups` (`name`, `minfilestoformrelease`, `minsizetoformrelease`, `description`) VALUES ('alt.binaries.multimedia.erotica.asian', 5, 31457280, 'erotica Asian');
+INSERT IGNORE INTO `groups` (`name`, `minfilestoformrelease`, `minsizetoformrelease`, `description`) VALUES ('alt.binaries.mp3.audiobooks.scifi-fantasy', NULL, 10485760, 'Audiobooks');
+INSERT IGNORE INTO `groups` (`name`, `minfilestoformrelease`, `minsizetoformrelease`, `description`) VALUES ('alt.binaries.sounds.audiobooks.scifi-fantasy', NULL, 10485760, 'Audiobooks');
+INSERT IGNORE INTO `groups` (`name`, `minfilestoformrelease`, `minsizetoformrelease`, `description`) VALUES ('alt.binaries.mp3.abooks', 2, 10485760, 'Audiobooks');
+INSERT IGNORE INTO `groups` (`name`, `minfilestoformrelease`, `minsizetoformrelease`, `description`) VALUES ('alt.binaries.town.xxx', 5, 10485760, 'XXX videos');
+INSERT IGNORE INTO `groups` (`name`, `minfilestoformrelease`, `minsizetoformrelease`, `description`) VALUES ('alt.binaries.software', 2, 5048571, 'Software');
+INSERT IGNORE INTO `groups` (`name`, `minfilestoformrelease`, `minsizetoformrelease`, `description`) VALUES ('alt.binaries.nzbpirates', 5, NULL, 'Misc, mostly Erotica, and foreign movies ');
+INSERT IGNORE INTO `groups` (`name`, `minfilestoformrelease`, `minsizetoformrelease`, `description`) VALUES ('alt.binaries.town.cine', NULL, 10485760, 'Movies');
+INSERT IGNORE INTO `groups` (`name`, `minfilestoformrelease`, `minsizetoformrelease`, `description`) VALUES ('alt.binaries.usenet-space-cowboys', 0, 0, 'Misc, mostly German');
+INSERT IGNORE INTO `groups` (`name`, `minfilestoformrelease`, `minsizetoformrelease`, `description`) VALUES ('alt.binaries.warez.ibm-pc.games', 0, 0, 'misc, mostly games and applications');
+INSERT IGNORE INTO `groups` (`name`, `minfilestoformrelease`, `minsizetoformrelease`, `description`) VALUES ('alt.binaries.warez.games', 0, 0, 'misc, mostly games and applications');
+INSERT IGNORE INTO `groups` (`name`, `minfilestoformrelease`, `minsizetoformrelease`, `description`) VALUES ('alt.binaries.e-book.magazines', NULL, 104857, 'magazines, mostly english');
+INSERT IGNORE INTO `groups` (`name`, `minfilestoformrelease`, `minsizetoformrelease`, `description`) VALUES ('alt.binaries.sounds.anime', 0, 0, 'music from Anime');
+
+UPDATE `site` set `value` = '169' where `setting` = 'sqlpatch';

--- a/db/pgsql_patches/2014_01_20_1_groups.sql
+++ b/db/pgsql_patches/2014_01_20_1_groups.sql
@@ -1,0 +1,72 @@
+BEGIN
+	INSERT INTO `groups` (`name`, `minfilestoformrelease`, `minsizetoformrelease`, `description`) VALUES ('alt.binaries.multimedia.erotica.anime', 5, 31457280, 'erotica anime');
+  EXCEPTION WHEN unique_violation THEN
+    -- Ignore duplicate inserts.
+END;
+BEGIN
+	INSERT INTO `groups` (`name`, `minfilestoformrelease`, `minsizetoformrelease`, `description`) VALUES ('alt.binaries.multimedia.erotica.asian', 5, 31457280, 'erotica Asian');
+  EXCEPTION WHEN unique_violation THEN
+    -- Ignore duplicate inserts.
+END;
+BEGIN
+	INSERT INTO `groups` (`name`, `minfilestoformrelease`, `minsizetoformrelease`, `description`) VALUES ('alt.binaries.mp3.audiobooks.scifi-fantasy', NULL, 10485760, 'Audiobooks');
+  EXCEPTION WHEN unique_violation THEN
+    -- Ignore duplicate inserts.
+END;
+BEGIN
+	INSERT INTO `groups` (`name`, `minfilestoformrelease`, `minsizetoformrelease`, `description`) VALUES ('alt.binaries.sounds.audiobooks.scifi-fantasy', NULL, 10485760, 'Audiobooks');
+  EXCEPTION WHEN unique_violation THEN
+    -- Ignore duplicate inserts.
+END;
+BEGIN
+	INSERT INTO `groups` (`name`, `minfilestoformrelease`, `minsizetoformrelease`, `description`) VALUES ('alt.binaries.mp3.abooks', 2, 10485760, 'Audiobooks');
+  EXCEPTION WHEN unique_violation THEN
+    -- Ignore duplicate inserts.
+END;
+BEGIN
+	INSERT INTO `groups` (`name`, `minfilestoformrelease`, `minsizetoformrelease`, `description`) VALUES ('alt.binaries.town.xxx', 5, 10485760, 'XXX videos');
+  EXCEPTION WHEN unique_violation THEN
+    -- Ignore duplicate inserts.
+END;
+BEGIN
+	INSERT INTO `groups` (`name`, `minfilestoformrelease`, `minsizetoformrelease`, `description`) VALUES ('alt.binaries.software', 2, 5048571, 'Software');
+  EXCEPTION WHEN unique_violation THEN
+    -- Ignore duplicate inserts.
+END;
+BEGIN
+	INSERT INTO `groups` (`name`, `minfilestoformrelease`, `minsizetoformrelease`, `description`) VALUES ('alt.binaries.nzbpirates', 5, NULL, 'Misc, mostly Erotica, and foreign movies ');
+  EXCEPTION WHEN unique_violation THEN
+    -- Ignore duplicate inserts.
+END;
+BEGIN
+	INSERT INTO `groups` (`name`, `minfilestoformrelease`, `minsizetoformrelease`, `description`) VALUES ('alt.binaries.town.cine', NULL, 10485760, 'Movies');
+  EXCEPTION WHEN unique_violation THEN
+    -- Ignore duplicate inserts.
+END;
+BEGIN
+	INSERT INTO `groups` (`name`, `minfilestoformrelease`, `minsizetoformrelease`, `description`) VALUES ('alt.binaries.usenet-space-cowboys', 0, 0, 'Misc, mostly German');
+  EXCEPTION WHEN unique_violation THEN
+    -- Ignore duplicate inserts.
+END;
+BEGIN
+	INSERT INTO `groups` (`name`, `minfilestoformrelease`, `minsizetoformrelease`, `description`) VALUES ('alt.binaries.warez.ibm-pc.games', 0, 0, 'misc, mostly games and applications');
+  EXCEPTION WHEN unique_violation THEN
+    -- Ignore duplicate inserts.
+END;
+BEGIN
+	INSERT INTO `groups` (`name`, `minfilestoformrelease`, `minsizetoformrelease`, `description`) VALUES ('alt.binaries.warez.games', 0, 0, 'misc, mostly games and applications');
+  EXCEPTION WHEN unique_violation THEN
+    -- Ignore duplicate inserts.
+END;
+BEGIN
+	INSERT INTO `groups` (`name`, `minfilestoformrelease`, `minsizetoformrelease`, `description`) VALUES ('alt.binaries.e-book.magazines', NULL, 104857, 'magazines, mostly english');
+  EXCEPTION WHEN unique_violation THEN
+    -- Ignore duplicate inserts.
+END;
+BEGIN
+	INSERT INTO `groups` (`name`, `minfilestoformrelease`, `minsizetoformrelease`, `description`) VALUES ('alt.binaries.sounds.anime', 0, 0, 'music from Anime');
+  EXCEPTION WHEN unique_violation THEN
+    -- Ignore duplicate inserts.
+END;
+
+UPDATE `site` set `value` = '169' where `setting` = 'sqlpatch';

--- a/db/schema.mysql
+++ b/db/schema.mysql
@@ -650,6 +650,20 @@ INSERT INTO groups (name, description, minfilestoformrelease, minsizetoformrelea
 INSERT INTO groups (name, description, minfilestoformrelease, minsizetoformrelease) VALUES ('alt.binaries.worms','I have no idea what this group contains besides a lot of U4ALL which isn\'t really usable.', 2, NULL);
 INSERT INTO groups (name, description, minfilestoformrelease, minsizetoformrelease) VALUES ('alt.binaries.x264','This group contains X264 Movies and TV.', NULL, NULL);
 INSERT INTO groups (name, description, minfilestoformrelease, minsizetoformrelease) VALUES ('alt.binaries.x','This group contains a variety of content. Some Foreign.', NULL, NULL);
+INSERT INTO groups (name, minfilestoformrelease, minsizetoformrelease, description) VALUES ('alt.binaries.multimedia.erotica.anime', 5, 31457280, 'erotica anime');
+INSERT INTO groups (name, minfilestoformrelease, minsizetoformrelease, description) VALUES ('alt.binaries.multimedia.erotica.asian', 5, 31457280, 'erotica Asian');
+INSERT INTO groups (name, minfilestoformrelease, minsizetoformrelease, description) VALUES ('alt.binaries.mp3.audiobooks.scifi-fantasy', NULL, 10485760, 'Audiobooks');
+INSERT INTO groups (name, minfilestoformrelease, minsizetoformrelease, description) VALUES ('alt.binaries.sounds.audiobooks.scifi-fantasy', NULL, 10485760, 'Audiobooks');
+INSERT INTO groups (name, minfilestoformrelease, minsizetoformrelease, description) VALUES ('alt.binaries.mp3.abooks', 2, 10485760, 'Audiobooks');
+INSERT INTO groups (name, minfilestoformrelease, minsizetoformrelease, description) VALUES ('alt.binaries.town.xxx', 5, 10485760, 'XXX videos');
+INSERT INTO groups (name, minfilestoformrelease, minsizetoformrelease, description) VALUES ('alt.binaries.software', 2, 5048571, 'Software');
+INSERT INTO groups (name, minfilestoformrelease, minsizetoformrelease, description) VALUES ('alt.binaries.nzbpirates', 5, NULL, 'Misc, mostly Erotica, and foreign movies ');
+INSERT INTO groups (name, minfilestoformrelease, minsizetoformrelease, description) VALUES ('alt.binaries.town.cine', NULL, 10485760, 'Movies');
+INSERT INTO groups (name, minfilestoformrelease, minsizetoformrelease, description) VALUES ('alt.binaries.usenet-space-cowboys', 0, 0, 'Misc, mostly German');
+INSERT INTO groups (name, minfilestoformrelease, minsizetoformrelease, description) VALUES ('alt.binaries.warez.ibm-pc.games', 0, 0, 'misc, mostly games and applications');
+INSERT INTO groups (name, minfilestoformrelease, minsizetoformrelease, description) VALUES ('alt.binaries.warez.games', 0, 0, 'misc, mostly games and applications');
+INSERT INTO groups (name, minfilestoformrelease, minsizetoformrelease, description) VALUES ('alt.binaries.e-book.magazines', NULL, 104857, 'magazines, mostly english');
+INSERT INTO groups (name, minfilestoformrelease, minsizetoformrelease, description) VALUES ('alt.binaries.sounds.anime', 0, 0, 'music from Anime');
 
 DROP TABLE IF EXISTS parts;
 CREATE TABLE parts (

--- a/db/schema.pgsql
+++ b/db/schema.pgsql
@@ -1287,6 +1287,20 @@ INSERT INTO groups (name, description, minfilestoformrelease, minsizetoformrelea
 INSERT INTO groups (name, description, minfilestoformrelease, minsizetoformrelease) VALUES ('alt.binaries.worms','I have no idea what this group contains besides a lot of U4ALL which isnt really usable.', 2, NULL);
 INSERT INTO groups (name, description, minfilestoformrelease, minsizetoformrelease) VALUES ('alt.binaries.x264','This group contains X264 Movies and TV.', NULL, NULL);
 INSERT INTO groups (name, description, minfilestoformrelease, minsizetoformrelease) VALUES ('alt.binaries.x','This group contains a variety of content. Some Foreign.', NULL, NULL);
+INSERT INTO groups (name, minfilestoformrelease, minsizetoformrelease, description) VALUES ('alt.binaries.multimedia.erotica.anime', 5, 31457280, 'erotica anime');
+INSERT INTO groups (name, minfilestoformrelease, minsizetoformrelease, description) VALUES ('alt.binaries.multimedia.erotica.asian', 5, 31457280, 'erotica Asian');
+INSERT INTO groups (name, minfilestoformrelease, minsizetoformrelease, description) VALUES ('alt.binaries.mp3.audiobooks.scifi-fantasy', NULL, 10485760, 'Audiobooks');
+INSERT INTO groups (name, minfilestoformrelease, minsizetoformrelease, description) VALUES ('alt.binaries.sounds.audiobooks.scifi-fantasy', NULL, 10485760, 'Audiobooks');
+INSERT INTO groups (name, minfilestoformrelease, minsizetoformrelease, description) VALUES ('alt.binaries.mp3.abooks', 2, 10485760, 'Audiobooks');
+INSERT INTO groups (name, minfilestoformrelease, minsizetoformrelease, description) VALUES ('alt.binaries.town.xxx', 5, 10485760, 'XXX videos');
+INSERT INTO groups (name, minfilestoformrelease, minsizetoformrelease, description) VALUES ('alt.binaries.software', 2, 5048571, 'Software');
+INSERT INTO groups (name, minfilestoformrelease, minsizetoformrelease, description) VALUES ('alt.binaries.nzbpirates', 5, NULL, 'Misc, mostly Erotica, and foreign movies ');
+INSERT INTO groups (name, minfilestoformrelease, minsizetoformrelease, description) VALUES ('alt.binaries.town.cine', NULL, 10485760, 'Movies');
+INSERT INTO groups (name, minfilestoformrelease, minsizetoformrelease, description) VALUES ('alt.binaries.usenet-space-cowboys', 0, 0, 'Misc, mostly German');
+INSERT INTO groups (name, minfilestoformrelease, minsizetoformrelease, description) VALUES ('alt.binaries.warez.ibm-pc.games', 0, 0, 'misc, mostly games and applications');
+INSERT INTO groups (name, minfilestoformrelease, minsizetoformrelease, description) VALUES ('alt.binaries.warez.games', 0, 0, 'misc, mostly games and applications');
+INSERT INTO groups (name, minfilestoformrelease, minsizetoformrelease, description) VALUES ('alt.binaries.e-book.magazines', NULL, 104857, 'magazines, mostly english');
+INSERT INTO groups (name, minfilestoformrelease, minsizetoformrelease, description) VALUES ('alt.binaries.sounds.anime', 0, 0, 'music from Anime');
 
 
 INSERT INTO menu (href, title, tooltip, role, ordinal ) VALUES ('search','Advanced Search','Search for releases.', 1, 10);

--- a/misc/testing/DB/populate_anidb.php
+++ b/misc/testing/DB/populate_anidb.php
@@ -14,7 +14,7 @@ class AniDBstandAlone
 {
 	const CLIENTVER = 1;
 
-	function __construct($debug=false, $echooutput=true)
+	function __construct($debug=false, $echooutput=false)
 	{
 		$s = new Sites();
 		$this->site = $s->get();


### PR DESCRIPTION
Added a number of new groups, based on usenet posts between the 12th and the 17th of jan 2014.

Also fixed a logging issue in anidb (does not log as much to standard out no change to operation), 
I have to also make a number of changes for the new groups in NameCleaning.php, but I'll make that one, which is going to have to be large due to how NameCleaning is written after this one committed.

Note I do not have pgsql, so there patch for the groups there is based off best practices for inserting a new row, and failing gracefully if it already exists.  It appears in the past new groups simply were not added to pgsql due to this issue and no-one had worked around it so I gave it a shot.
