### PR TITLE
Fixed typo in patchDB from template_c to templates_c

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -7,6 +7,7 @@ Each update goes to the top of the file
 ***moved smarty path, please run sudo chmod -R 777 smarty/templates_c/***
 
 
+2014-01-14 -> egandt   -> typo in mis/testind/DB/patchDB for templates_c (was template_c)
 2014-01-24 -> bart39   -> fixed some collection cleaning regexes for requestid's
 2014-01-24 -> jonnyboy -> updated convert_to_mysql.php when using innodb compressed, to set releasenfo as innodb dynamic, since the content is compressed
 2014-01-24 -> bart39   -> changed book cover view so that books are grouped by bookinfoid (similar concept to movie cover view)

--- a/misc/testing/DB/patchDB.php
+++ b/misc/testing/DB/patchDB.php
@@ -192,6 +192,6 @@ if ($patched > 0) {
 	if ($cleared) {
 		echo $c->header("The smarty template cache has been cleaned for you");
 	} else {
-		echo $c->header("You should clear your smarty template cache at: " . SMARTY_DIR . "template_c");
+		echo $c->header("You should clear your smarty template cache at: " . SMARTY_DIR . "templates_c");
 	}
 }


### PR DESCRIPTION
Fixed typo in patchDB from template_c to templates_c, not really sure this required a changelog update, but why not.
