### PR TITLE
Fix Typo on Tmux monitor.php

### DIFF
--- a/misc/update/nix/tmux/monitor.php
+++ b/misc/update/nix/tmux/monitor.php
@@ -1660,7 +1660,7 @@ function run_ircscraper($tmux_session, $_php, $pane, $scrape_cz, $scrape_efnet)
 			$ircscraper = $DIR . "testing/IRCScraper/scrape.php";
 			shell_exec(
 				"tmux respawnp -t${tmux_session}:${pane}.0 ' \
-						$_php $ircscraper efne false false true'"
+						$_php $ircscraper efnet false false true'"
 			);
 		}
 	} else {


### PR DESCRIPTION
Typo on "efnet" causing tmux IRCScraper window to error.
