### PR TITLE
Fix typo preventing covers from loading in Nginx

### DIFF
--- a/misc/urlrewriting/nginx.txt
+++ b/misc/urlrewriting/nginx.txt
@@ -24,7 +24,7 @@ server {
 			root /home/www/example.com//resources
 		}
 
-		location ~* \.(?:css|jpe?g|gif|ogg|ogv|png|js|ico|ttf|eot|woff|svg) { 
+		location ~* \.(?:css|jpeg|gif|ogg|ogv|png|js|ico|ttf|eot|woff|svg) { 
 			expires max;
 			add_header Pragma public;
 			add_header Cache-Control "public, must-revalidate, proxy-revalidate";


### PR DESCRIPTION
There was a typo in the example Nginx configuration preventing jpeg files from redirecting properly.
