### PR TITLE
Correct error in blacklist query by poster

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -3,6 +3,8 @@ No pull requests will be accepted without this file being updated to reflect wha
 No pull requests will be accepted to any branch except the dev branch.
 New updates are grouped by person, at the top of the file.
 
+2014-10-10 bfincher
+	* New: Correct error in blacklist query by poster.
 2014-10-10 ruhllatio
 	* Mrg: Merge dev-api into dev for nzb360 movie cover compatibility
 2014-10-10 bart39

--- a/nzedb/controllers/ReleaseRemover.php
+++ b/nzedb/controllers/ReleaseRemover.php
@@ -827,7 +827,11 @@ class ReleaseRemover
 					)
 				);
 
-				$join = (nZEDb_RELEASE_SEARCH_TYPE == \ReleaseSearch::SPHINX ? "INNER JOIN releases_se rse ON rse.id = r.id" : "INNER JOIN releasesearch rs ON rs.releaseid = r.id");
+                                if ($opTypeName == "Subject") {
+   				    $join = (nZEDb_RELEASE_SEARCH_TYPE == \ReleaseSearch::SPHINX ? "INNER JOIN releases_se rse ON rse.id = r.id" : "INNER JOIN releasesearch rs ON rs.releaseid = r.id");
+				} else {
+ 				    $join = "";
+				}
 
 				$this->query = sprintf("
 							SELECT r.guid, r.searchname, r.id


### PR DESCRIPTION
The query by poster in ReleaseRemover incorrectly joins the releases_se table and thus never matches.
