### PR TITLE
Login Page XSS Fix

### DIFF
--- a/www/pages/login.php
+++ b/www/pages/login.php
@@ -1,5 +1,9 @@
 <?php
 if ($page->isPostBack()) {
+	//Loop through post vars and escape them. This protects against XSS.
+	foreach($_POST as $key => $_) {
+		$_POST[$key] = htmlspecialchars($_POST[$key]);
+	}
 	if (!isset($_POST["username"]) || !isset($_POST["password"])) {
 		$page->smarty->assign('error', "Please enter your username and password.");
 	} else {


### PR DESCRIPTION
During a basic security audit I found the default login page had a cross site scripting vulnerability allowing an attacker to inject html and javascript into the running code by typing it into an input field.

This really should be done anywhere input fields are echo'd back to the user (like during a failed signup or login attempt).

Here's a screenshot of the successful security scan after I merged these changes into my production site: 
![image](https://cloud.githubusercontent.com/assets/1036810/5056132/2402ec68-6c41-11e4-9d8c-09f1b1b4ed45.png)
