### PR TITLE
Set Contact Us to use global email method.

### DIFF
--- a/www/pages/contact-us.php
+++ b/www/pages/contact-us.php
@@ -8,10 +8,12 @@ if (isset($_POST["useremail"])) {
 	$mailto = $page->settings->getSetting('email');
 
 	$mailsubj = "Contact Form Submitted";
-	$mailbody = "Values submitted from contact form:\n";
+	$mailbody = "Values submitted from contact form:<br/>";
 
 	while (list ($key, $val) = each($_POST)) {
-		$mailbody .= "$key : $val\n";
+		if ($key != "submit") {
+			$mailbody .= "$key : $val<br/>";
+		}
 	}
 
 	if (!preg_match("/\n/i", $_POST["useremail"])) {


### PR DESCRIPTION
The contact-us page was using a direct to local mail() call instead of using the global Utility::sendEmail(). If a user has PHPMailer set to use SMTP, it's possible these emails would never arrive before this change.
