### PR TITLE
Mail: Use supplied from address as reply-to.

### DIFF
--- a/nzedb/utility/Utility.php
+++ b/nzedb/utility/Utility.php
@@ -1091,12 +1091,9 @@ class Utility
 
 		$settings = new Settings();
 
-		$site_email = $settings->getSetting('email');
-
-		$fromEmail = (PHPMAILER_FROM_EMAIL == '') ? $site_email : PHPMAILER_FROM_EMAIL;
-		$fromName  = (PHPMAILER_FROM_NAME == '') ? $settings->getSetting('title') :
-			PHPMAILER_FROM_NAME;
-		$replyTo   = (PHPMAILER_REPLYTO == '') ? $site_email : PHPMAILER_REPLYTO;
+		$fromEmail = (PHPMAILER_FROM_EMAIL == '') ? $settings->getSetting('email') : PHPMAILER_FROM_EMAIL;
+		$fromName  = (PHPMAILER_FROM_NAME == '') ? $settings->getSetting('title') : PHPMAILER_FROM_NAME;
+		$replyTo   = (PHPMAILER_REPLYTO == '') ? $from : PHPMAILER_REPLYTO;
 
 		if (PHPMAILER_BCC != '') {
 			$mail->addBCC(PHPMAILER_BCC);


### PR DESCRIPTION
Previously the supplied From address in the sendEmail function was being ignored (unless you were using the fallback). I set it to use the from address as the reply-to. I considered setting From as the actual from address but I think this is a safer bet since the email was not sent from them but rather from your site.

Let me know what you guys think.
