### PR TITLE
Fix lighthttpd rewrite rule.

### DIFF
--- a/docs/urlrewriting/lighttpd.txt
+++ b/docs/urlrewriting/lighttpd.txt
@@ -1,5 +1,5 @@
 url.rewrite-once = (
-	"^/.*\.(css|jpg|jpeg|gif|png|js|ico)" => "$0",
+	"^/.*\.(css|eot|gif|gz|ico|inc|jpe?g|js|ogg|png|svg|ttf|txt|woff|xml)$" => "$0",
 	"^/(admin|install).*$" => "$0",
 	"^/([^/\.]+)/?(?:\?(.*))$" => "index.php?page=$1&$2",
 	"^/([^/\.]+)/?$" => "index.php?page=$1",

--- a/www/.htaccess
+++ b/www/.htaccess
@@ -2,7 +2,7 @@ RewriteEngine on
 #RewriteBase /
 
 # Do not process images or CSS files further
-RewriteRule \.(css|jpe?g|gif|ogg|ogv|png|js|ico|ttf|eot|woff|svg)$ - [L]
+RewriteRule \.(css|eot|gif|gz|ico|inc|jpe?g|js|ogg|png|svg|ttf|txt|woff|xml)$ - [L]
 
 # Leave /admin and /install static
 RewriteRule ^(admin|install).*$ - [L]


### PR DESCRIPTION
Update lighthttpd and apache rewrite rule to be up to date with the nginx
one.

Users using Nginx should change their config file to use the new rewrite rule for the css/images, the old one will cause 404 on certain pages. See https://github.com/nZEDb/nZEDb_Misc/commit/2b97bb1c1d056747f2f689d991003d01dc595486#diff-7412d4a4b0f3b93824e2cf37297e1c51 for what to change.
