### PR TITLE
Force read/write on group level for the log file. #1598

### DIFF
--- a/nzedb/controllers/Logger.php
+++ b/nzedb/controllers/Logger.php
@@ -535,6 +535,7 @@ class Logger
 			) {
 				throw new \LoggerException('Unable to create new log file ' . $this->logPath);
 			}
+			chmod($this->logPath, 0664);
 		}
 	}
 


### PR DESCRIPTION
Set the -rw-rw-r-- permissions on the log file on creation.

See https://github.com/nZEDb/nZEDb/issues/1598