### PR TITLE
Fixes for compressed NZB reading and return.

### DIFF
--- a/nzedb/controllers/NZB.php
+++ b/nzedb/controllers/NZB.php
@@ -323,8 +323,7 @@ class NZB
 			return $result;
 		}
 
-		$nzb = str_replace("\x0F", '', $nzb);
-		$xml = @simplexml_load_string($nzb);
+		$xml = @simplexml_load_string(str_replace("\x0F", '', $nzb));
 		if (!$xml || strtolower($xml->getName()) !== 'nzb') {
 			return $result;
 		}

--- a/nzedb/processing/post/ProcessAdditional.php
+++ b/nzedb/processing/post/ProcessAdditional.php
@@ -756,17 +756,8 @@ Class ProcessAdditional
 			@umask($old);
 
 			if (!is_dir($this->tmpPath)) {
-
 				$this->_echo('Unable to create directory: ' . $this->tmpPath, 'warning');
-
-				// Decrement password status.
-				$this->pdo->queryExec(
-					sprintf(
-						'UPDATE releases SET passwordstatus = passwordstatus - 1 WHERE id = %d',
-						$this->_release['id']
-					)
-				);
-				return false;
+				return $this->_decrementPasswordStatus();
 			}
 		}
 		return true;
@@ -781,41 +772,44 @@ Class ProcessAdditional
 	{
 		$nzbPath = $this->_nzb->NZBPath($this->_release['guid']);
 		if ($nzbPath === false) {
-
 			$this->_echo('NZB not found for GUID: ' . $this->_release['guid'], 'warning');
-
-			// The nzb was not located. decrement the password status.
-			$this->pdo->queryExec(
-				sprintf(
-					'UPDATE releases SET passwordstatus = passwordstatus - 1 WHERE id = %d',
-					$this->_release['id']
-				)
-			);
-			return false;
+			return $this->_decrementPasswordStatus();
 		}
 
 		$nzbContents = Utility::unzipGzipFile($nzbPath);
+		if (!$nzbContents) {
+			$this->_echo('NZB is empty or broken for GUID: ' . $this->_release['guid'], 'warning');
+			return $this->_decrementPasswordStatus();
+		}
 
 		// Get a list of files in the nzb.
 		$this->_nzbContents = $this->_nzb->nzbFileList($nzbContents);
 		if (count($this->_nzbContents) === 0) {
-
-			$this->_echo('NZB is empty or broken for GUID: ' . $this->_release['guid'], 'warning');
-
-			// There does not appear to be any files in the nzb, decrement password status.
-			$this->pdo->queryExec(
-				sprintf(
-					'UPDATE releases SET passwordstatus = passwordstatus - 1 WHERE id = %d',
-					$this->_release['id']
-				)
-			);
-			return false;
+			return $this->_decrementPasswordStatus();
 		}
 
 		// Sort the files inside the NZB.
 		usort($this->_nzbContents, ['\nzedb\processing\post\ProcessAdditional', '_sortNZB']);
 
 		return true;
+	}
+
+	/**
+	 * Decrement password status for the current release.
+	 *
+	 * @param bool $return Return value.
+	 *
+	 * @return bool
+	 */
+	protected function _decrementPasswordStatus($return = false)
+	{
+		$this->pdo->queryExec(
+			sprintf(
+				'UPDATE releases SET passwordstatus = passwordstatus - 1 WHERE id = %d',
+				$this->_release['id']
+			)
+		);
+		return $return;
 	}
 
 	/**
@@ -1605,10 +1599,9 @@ Class ProcessAdditional
 		// If we failed to get anything from the RAR/ZIPs, decrement the passwordstatus, if the rar/zip has no password.
 		if ($this->_releaseHasPassword === false && $this->_NZBHasCompressedFile && $releaseFiles['count'] == 0) {
 			$query = sprintf(
-				'
-								UPDATE releases
-								SET passwordstatus = passwordstatus - 1, rarinnerfilecount = %d %s %s %s
-								WHERE id = %d',
+				'UPDATE releases
+				SET passwordstatus = passwordstatus - 1, rarinnerfilecount = %d %s %s %s
+				WHERE id = %d',
 				$releaseFiles['count'],
 				$iSQL,
 				$vSQL,
@@ -1618,8 +1611,7 @@ Class ProcessAdditional
 		} // Else update the release with the password status (if the admin enabled the setting).
 		else {
 			$query = sprintf(
-				'
-				UPDATE releases
+				'UPDATE releases
 				SET passwordstatus = %d, rarinnerfilecount = %d %s %s %s
 				WHERE id = %d',
 				($this->_processPasswords === true ? $this->_passwordStatus : \Releases::PASSWD_NONE),

--- a/nzedb/processing/post/ProcessAdditional.php
+++ b/nzedb/processing/post/ProcessAdditional.php
@@ -785,6 +785,7 @@ Class ProcessAdditional
 		// Get a list of files in the nzb.
 		$this->_nzbContents = $this->_nzb->nzbFileList($nzbContents);
 		if (count($this->_nzbContents) === 0) {
+			$this->_echo('NZB is potentially broken for GUID: ' . $this->_release['guid'], 'warning');
 			return $this->_decrementPasswordStatus();
 		}
 

--- a/nzedb/utility/Utility.php
+++ b/nzedb/utility/Utility.php
@@ -470,32 +470,27 @@ class Utility
 	 */
 	static public function unzipGzipFile($filePath)
 	{
+		/* Potential issues with this, so commenting out.
 		$length = Utility::isGZipped($filePath);
 		if ($length === false || $length === null) {
 			return false;
-		}
+		}*/
 
-		// String to hold the NZB contents.
 		$string = '';
-		// Open the gzip file.
 		$gzFile = @gzopen($filePath, 'rb', 0);
 		if ($gzFile) {
-			// Append the decompressed data to the string until we find the end of file pointer.
 			while (!gzeof($gzFile)) {
 				$temp = gzread($gzFile, 1024);
-				// Check for corrupt data, there will be no end of file, so the loop would go on and on taking 100% CPU.
-				if ($temp) {
-					$string .= $temp;
-				} else {
-					// If the data was corrupt, set the big string empty so we return false and break out of the loop.
-					$string = '';
+				// Check for empty string.
+				// Without this the loop would be endless and consume 100% CPU.
+				// Do not set $string empty here, as the data might still be good.
+				if (!$temp) {
 					break;
 				}
+				$string .= $temp;
 			}
-			// Close the gzip file.
 			gzclose($gzFile);
 		}
-		// Return the string.
 		return ($string === '' ? false : $string);
 	}
 


### PR DESCRIPTION
Fixes an issue where if the last char of the decompressed text is within the 1024 bytes buffer the EOF is not found and gzread returned an empty string, which triggered our corruption check and would return an empty string even though the data was not corrupt. (this might be due to no EOF on the ending `</nzb>` tag, the NZB spec does not say a EOF is needed after the ending `</nzb>` tag, and I could not find a site that does have a EOF on the ending `</nzb>` tag).