### PR TITLE
Faster / more random hex string gen (for release guid and binary hash).

### DIFF
--- a/nzedb/controllers/Binaries.php
+++ b/nzedb/controllers/Binaries.php
@@ -718,7 +718,7 @@ class Binaries
 							$groupMySQL['id'],
 							$fileCount[3],
 							sha1($header['CollectionKey']),
-							md5(uniqid('', true) . mt_rand())
+							bin2hex(openssl_random_pseudo_bytes(32))
 						)
 					);
 

--- a/nzedb/controllers/Binaries.php
+++ b/nzedb/controllers/Binaries.php
@@ -718,7 +718,7 @@ class Binaries
 							$groupMySQL['id'],
 							$fileCount[3],
 							sha1($header['CollectionKey']),
-							bin2hex(openssl_random_pseudo_bytes(32))
+							bin2hex(openssl_random_pseudo_bytes(16))
 						)
 					);
 

--- a/nzedb/controllers/Releases.php
+++ b/nzedb/controllers/Releases.php
@@ -101,7 +101,7 @@ class Releases
 	 */
 	public function createGUID()
 	{
-		return sha1(uniqid('', true) . mt_rand());
+		return bin2hex(openssl_random_pseudo_bytes(40));
 	}
 
 	/**

--- a/nzedb/controllers/Releases.php
+++ b/nzedb/controllers/Releases.php
@@ -101,7 +101,7 @@ class Releases
 	 */
 	public function createGUID()
 	{
-		return bin2hex(openssl_random_pseudo_bytes(40));
+		return bin2hex(openssl_random_pseudo_bytes(20));
 	}
 
 	/**


### PR DESCRIPTION
Uses openssl's PRNG, for better entropy than the old method.

This is about 20-40% faster than the old method.

Based on my test below:

<?php
$time = microtime(true);
$string = '';
for ($i = 0; $i < 5000000; $i++) {
	$string = bin2hex(openssl_random_pseudo_bytes(16));
}
echo (microtime(true) - $time) . 's' . PHP_EOL;

$time = microtime(true);
$string = '';
for ($i = 0; $i < 5000000; $i++) {
	$string = md5(uniqid('', true) . mt_rand());
}
echo (microtime(true) - $time) . 's' . PHP_EOL;
?>