### PR TITLE
Add support for category regexes in the DB.

### DIFF
--- a/nzedb/controllers/Regexes.php
+++ b/nzedb/controllers/Regexes.php
@@ -18,6 +18,11 @@ Class Regexes
 	protected $_regexCache;
 
 	/**
+	 * @var int
+	 */
+	protected $_categoryID = Category::CAT_MISC;
+
+	/**
 	 * @param array $options
 	 */
 	public function __construct(array $options = array())
@@ -43,13 +48,15 @@ Class Regexes
 	{
 		return (bool)$this->pdo->queryInsert(
 			sprintf(
-				'INSERT INTO %s (group_regex, regex, status, description, ordinal) VALUES (%s, %s, %d, %s, %d)',
+				'INSERT INTO %s (group_regex, regex, status, description, ordinal%s) VALUES (%s, %s, %d, %s, %d%s)',
 				$this->tableName,
+				($this->tableName === 'category_regexes' ? ', category_id' : ''),
 				trim($this->pdo->escapeString($data['group_regex'])),
 				trim($this->pdo->escapeString($data['regex'])),
 				$data['status'],
 				trim($this->pdo->escapeString($data['description'])),
-				$data['ordinal']
+				$data['ordinal'],
+				($this->tableName === 'category_regexes' ? (', ' . $data['category_id']) : '')
 			)
 		);
 	}
@@ -66,7 +73,7 @@ Class Regexes
 		return (bool)$this->pdo->queryExec(
 			sprintf(
 				'UPDATE %s
-				SET group_regex = %s, regex = %s, status = %d, description = %s, ordinal = %d
+				SET group_regex = %s, regex = %s, status = %d, description = %s, ordinal = %d %s
 				WHERE id = %d',
 				$this->tableName,
 				trim($this->pdo->escapeString($data['group_regex'])),
@@ -74,6 +81,7 @@ Class Regexes
 				$data['status'],
 				trim($this->pdo->escapeString($data['description'])),
 				$data['ordinal'],
+				($this->tableName === 'category_regexes' ? (', category_id = ' . $data['category_id']) : ''),
 				$data['id']
 			)
 		);
@@ -277,6 +285,10 @@ Class Regexes
 		if ($this->_regexCache[$groupName]['regex']) {
 			foreach ($this->_regexCache[$groupName]['regex'] as $regex) {
 
+				if ($this->tableName === 'category_regexes') {
+					$this->_categoryID = $regex['category_id'];
+				}
+
 				$returnString = $this->_matchRegex($regex['regex'], $subject);
 				// If this regex found something, break and return, or else continue trying other regex.
 				if ($returnString) {
@@ -303,7 +315,8 @@ Class Regexes
 		// Get all regex from DB which match the current group name. Cache them for 15 minutes. #CACHEDQUERY#
 		$this->_regexCache[$groupName]['regex'] = $this->pdo->query(
 			sprintf(
-				'SELECT c.regex FROM %s c WHERE %s REGEXP c.group_regex AND c.status = 1 ORDER BY c.ordinal ASC, c.group_regex ASC',
+				'SELECT r.regex%s FROM %s r WHERE %s REGEXP r.group_regex AND r.status = 1 ORDER BY r.ordinal ASC, r.group_regex ASC',
+				($this->tableName === 'category_regexes' ? ', r.category_id' : ''),
 				$this->tableName,
 				$this->pdo->escapeString($groupName)
 			), true, 900
@@ -330,15 +343,19 @@ Class Regexes
 				// Sort the keys, the named key matches will be concatenated in this order.
 				ksort($matches);
 				foreach ($matches as $key => $value) {
-					// Ignore non-named capture groups. Only named capture groups are important.
-					if (is_int($key)) {
-						continue;
+					switch ($this->tableName) {
+						case 'collection_naming_regexes': // Put this at the top since it's the most important for performance.
+						case 'release_naming_regexes':
+							// Ignore non-named capture groups. Only named capture groups are important.
+							if (is_int($key) || preg_match('#reqid|parts#i', $key)) {
+								continue 2;
+							}
+							$returnString .= $value; // Concatenate the string to return.
+							break;
+						case 'category_regexes':
+							$returnString = $this->_categoryID; // Regex matched, so return the category ID.
+							break 2;
 					}
-					if ($this->tableName === 'release_naming_regexes' && !preg_match('#reqid|parts#i', $key)) {
-						continue;
-					}
-					// Concatenate the string to return.
-					$returnString .= $value;
 				}
 			}
 		}

--- a/resources/db/patches/mysql/+1~regexes.sql
+++ b/resources/db/patches/mysql/+1~regexes.sql
@@ -1,0 +1,25 @@
+ALTER TABLE release_naming_regexes MODIFY COLUMN group_regex VARCHAR(255) NOT NULL DEFAULT '' COMMENT 'This is a regex to match against usenet groups';
+ALTER TABLE release_naming_regexes MODIFY COLUMN regex VARCHAR(5000) NOT NULL DEFAULT '' COMMENT 'Regex used for extracting name from subject';
+ALTER TABLE release_naming_regexes MODIFY COLUMN description VARCHAR(1000) NOT NULL DEFAULT '' COMMENT 'Optional extra details on this regex';
+ALTER TABLE collection_regexes MODIFY COLUMN group_regex VARCHAR(255) NOT NULL DEFAULT '' COMMENT 'This is a regex to match against usenet groups';
+ALTER TABLE collection_regexes MODIFY COLUMN regex VARCHAR(5000) NOT NULL DEFAULT '' COMMENT 'Regex used for collection grouping';
+ALTER TABLE collection_regexes MODIFY COLUMN description VARCHAR(1000) NOT NULL DEFAULT '' COMMENT 'Optional extra details on this regex';
+DROP TABLE IF EXISTS category_regexes;
+CREATE TABLE category_regexes (
+  id          INT UNSIGNED        NOT NULL AUTO_INCREMENT,
+  group_regex VARCHAR(255)        NOT NULL DEFAULT ''     COMMENT 'This is a regex to match against usenet groups',
+  regex       VARCHAR(5000)       NOT NULL DEFAULT ''     COMMENT 'Regex used to match a release name to categorize it',
+  status      TINYINT(1) UNSIGNED NOT NULL DEFAULT '1'    COMMENT '1=ON 0=OFF',
+  description VARCHAR(1000)       NOT NULL DEFAULT ''     COMMENT 'Optional extra details on this regex',
+  ordinal     INT SIGNED          NOT NULL DEFAULT '0'    COMMENT 'Order to run the regex in',
+  category_id SMALLINT UNSIGNED   NOT NULL DEFAULT '7010' COMMENT 'Which category id to put the release in',
+  PRIMARY KEY (id),
+  INDEX ix_category_regexes_group_regex (group_regex),
+  INDEX ix_category_regexes_status      (status),
+  INDEX ix_category_regexes_ordinal     (ordinal),
+  INDEX ix_category_regexes_category_id (category_id)
+)
+  ENGINE          = MYISAM
+  DEFAULT CHARSET = utf8
+  COLLATE         = utf8_unicode_ci
+  AUTO_INCREMENT  = 100000;

--- a/resources/db/patches/mysql/+1~regexes.sql
+++ b/resources/db/patches/mysql/+1~regexes.sql
@@ -23,3 +23,13 @@ CREATE TABLE category_regexes (
   DEFAULT CHARSET = utf8
   COLLATE         = utf8_unicode_ci
   AUTO_INCREMENT  = 100000;
+INSERT INTO category_regexes (id, group_regex, regex, status, description, ordinal, category_id)
+  VALUES (
+    1,
+    'alt\\.binaries\\.sony\\.psvita',
+    '/.*/',
+    1,
+    '',
+    50,
+    1120
+);

--- a/resources/db/schema/data/10-category_regexes.tsv
+++ b/resources/db/schema/data/10-category_regexes.tsv
@@ -1,0 +1,2 @@
+id, group_regex, regex, status, description, ordinal, category_id
+1	alt\\.binaries\\.sony\\.psvita	/.*/ 	1		50	1120

--- a/resources/db/schema/mysql-ddl.sql
+++ b/resources/db/schema/mysql-ddl.sql
@@ -194,6 +194,27 @@ CREATE TABLE category (
   AUTO_INCREMENT = 1000001;
 
 
+DROP TABLE IF EXISTS category_regexes;
+CREATE TABLE category_regexes (
+  id          INT UNSIGNED        NOT NULL AUTO_INCREMENT,
+  group_regex VARCHAR(255)        NOT NULL DEFAULT ''     COMMENT 'This is a regex to match against usenet groups',
+  regex       VARCHAR(5000)       NOT NULL DEFAULT ''     COMMENT 'Regex used to match a release name to categorize it',
+  status      TINYINT(1) UNSIGNED NOT NULL DEFAULT '1'    COMMENT '1=ON 0=OFF',
+  description VARCHAR(1000)       NOT NULL DEFAULT ''     COMMENT 'Optional extra details on this regex',
+  ordinal     INT SIGNED          NOT NULL DEFAULT '0'    COMMENT 'Order to run the regex in',
+  category_id SMALLINT UNSIGNED   NOT NULL DEFAULT '7010' COMMENT 'Which category id to put the release in',
+  PRIMARY KEY (id),
+  INDEX ix_category_regexes_group_regex (group_regex),
+  INDEX ix_category_regexes_status      (status),
+  INDEX ix_category_regexes_ordinal     (ordinal),
+  INDEX ix_category_regexes_category_id (category_id)
+)
+  ENGINE          = MYISAM
+  DEFAULT CHARSET = utf8
+  COLLATE         = utf8_unicode_ci
+  AUTO_INCREMENT  = 100000;
+
+
 DROP TABLE IF EXISTS collections;
 CREATE TABLE         collections (
   id             INT(11) UNSIGNED    NOT NULL AUTO_INCREMENT,
@@ -226,12 +247,12 @@ CREATE TABLE         collections (
 
 DROP TABLE IF EXISTS collection_regexes;
 CREATE TABLE collection_regexes (
-  id          INT UNSIGNED  NOT NULL AUTO_INCREMENT,
-  group_regex VARCHAR(255)  NULL                          COMMENT 'This is a regex to match against usenet groups',
-  regex       VARCHAR(5000) NOT NULL                      COMMENT 'Regex used for collection grouping',
-  status      TINYINT(1)    UNSIGNED NOT NULL DEFAULT '1' COMMENT '1=ON 0=OFF',
-  description VARCHAR(1000) NOT NULL                      COMMENT 'Optional extra details on this regex',
-  ordinal     INT SIGNED    NOT NULL DEFAULT '0'          COMMENT 'Order to run the regex in',
+  id          INT UNSIGNED        NOT NULL AUTO_INCREMENT,
+  group_regex VARCHAR(255)        NOT NULL DEFAULT ''  COMMENT 'This is a regex to match against usenet groups',
+  regex       VARCHAR(5000)       NOT NULL DEFAULT ''  COMMENT 'Regex used for collection grouping',
+  status      TINYINT(1) UNSIGNED NOT NULL DEFAULT '1' COMMENT '1=ON 0=OFF',
+  description VARCHAR(1000)       NOT NULL             COMMENT 'Optional extra details on this regex',
+  ordinal     INT SIGNED          NOT NULL DEFAULT '0' COMMENT 'Order to run the regex in',
   PRIMARY KEY (id),
   INDEX ix_collection_regexes_group_regex (group_regex),
   INDEX ix_collection_regexes_status      (status),
@@ -748,12 +769,12 @@ CREATE TABLE release_files (
 
 DROP TABLE IF EXISTS release_naming_regexes;
 CREATE TABLE release_naming_regexes (
-  id          INT UNSIGNED  NOT NULL AUTO_INCREMENT,
-  group_regex VARCHAR(255)  NULL                          COMMENT 'This is a regex to match against usenet groups',
-  regex       VARCHAR(5000) NOT NULL                      COMMENT 'Regex used for extracting name from subject',
-  status      TINYINT(1)    UNSIGNED NOT NULL DEFAULT '1' COMMENT '1=ON 0=OFF',
-  description VARCHAR(1000) NOT NULL                      COMMENT 'Optional extra details on this regex',
-  ordinal     INT SIGNED    NOT NULL DEFAULT '0'          COMMENT 'Order to run the regex in',
+  id          INT UNSIGNED        NOT NULL AUTO_INCREMENT,
+  group_regex VARCHAR(255)        NOT NULL DEFAULT ''  COMMENT 'This is a regex to match against usenet groups',
+  regex       VARCHAR(5000)       NOT NULL DEFAULT ''  COMMENT 'Regex used for extracting name from subject',
+  status      TINYINT(1) UNSIGNED NOT NULL DEFAULT '1' COMMENT '1=ON 0=OFF',
+  description VARCHAR(1000)       NOT NULL DEFAULT ''  COMMENT 'Optional extra details on this regex',
+  ordinal     INT SIGNED          NOT NULL DEFAULT '0' COMMENT 'Order to run the regex in',
   PRIMARY KEY (id),
   INDEX ix_release_naming_regexes_group_regex (group_regex),
   INDEX ix_release_naming_regexes_status      (status),

--- a/www/admin/ajax.php
+++ b/www/admin/ajax.php
@@ -19,6 +19,12 @@ switch($_GET['action']) {
 		print "Blacklist $id deleted.";
 		break;
 
+	case 'category_regex_delete':
+		$id = (int) $_GET['row_id'];
+		(new Regexes(['Settings' => $admin->settings, 'Table_Name' => 'category_regexes']))->deleteRegex($id);
+		print "Regex $id deleted.";
+		break;
+
 	case 'collection_regex_delete':
 		$id = (int) $_GET['row_id'];
 		(new Regexes(['Settings' => $admin->settings, 'Table_Name' => 'collection_regexes']))->deleteRegex($id);

--- a/www/admin/category_regexes-edit.php
+++ b/www/admin/category_regexes-edit.php
@@ -1,0 +1,75 @@
+<?php
+require_once './config.php';
+
+$page = new AdminPage();
+$regexes = new Regexes(['Settings' => $page->settings, 'Table_Name' => 'category_regexes']);
+
+// Set the current action.
+$action = isset($_REQUEST['action']) ? $_REQUEST['action'] : 'view';
+
+switch($action) {
+	case 'submit':
+		if ($_POST["group_regex"] == '') {
+			$page->smarty->assign('error', "Group regex must not be empty!");
+			break;
+		}
+
+		if ($_POST["regex"] == '') {
+			$page->smarty->assign('error', "Regex cannot be empty");
+			break;
+		}
+
+		if ($_POST['description'] == '') {
+			$_POST['description'] = '';
+		}
+
+		if (!is_numeric($_POST['ordinal']) || $_POST['ordinal'] < 0) {
+			$page->smarty->assign('error', "Ordinal must be a number, 0 or higher.");
+			break;
+		}
+
+		if ($_POST["id"] == '') {
+			$regexes->addRegex($_POST);
+		} else {
+			$regexes->updateRegex($_POST);
+		}
+
+		header("Location:".WWW_TOP."/category_regexes-list.php");
+		break;
+
+	case 'view':
+	default:
+		if (isset($_GET["id"])) {
+			$page->title = "Category Regex Edit";
+			$id = $_GET["id"];
+			$r = $regexes->getRegexByID($id);
+		} else {
+			$page->title = "Category Regex Add";
+			$r = ['status' => 1];
+		}
+		$page->smarty->assign('regex', $r);
+		break;
+}
+
+$page->smarty->assign('status_ids', [Category::STATUS_ACTIVE,Category::STATUS_INACTIVE]);
+$page->smarty->assign('status_names', ['Yes', 'No']);
+
+$categories_db = $page->settings->queryDirect(
+	'SELECT c.id, c.title, cp.title AS parent_title
+	FROM category c
+	INNER JOIN category cp ON c.parentid = cp.id
+	WHERE c.parentid IS NOT NULL
+	ORDER BY c.id ASC'
+);
+$categories = ['category_names', 'category_ids'];
+if ($categories_db) {
+	foreach($categories_db as $category_db) {
+		$categories['category_names'][] = $category_db['parent_title'] . ' ' . $category_db['title'] . ': ' . $category_db['id'];
+		$categories['category_ids'][] = $category_db['id'];
+	}
+}
+$page->smarty->assign('category_names', $categories['category_names']);
+$page->smarty->assign('category_ids', $categories['category_ids']);
+
+$page->content = $page->smarty->fetch('category_regexes-edit.tpl');
+$page->render();

--- a/www/admin/category_regexes-list.php
+++ b/www/admin/category_regexes-list.php
@@ -1,0 +1,25 @@
+<?php
+require_once './config.php';
+
+$page = new AdminPage();
+$regexes = new Regexes(['Settings' => $page->settings, 'Table_Name' => 'category_regexes']);
+
+$page->title = "Category Regex List";
+
+$group = ((isset($_REQUEST['group']) && !empty($_REQUEST['group'])) ? $_REQUEST['group'] : '');
+$offset = (isset($_REQUEST["offset"]) ? $_REQUEST["offset"] : 0);
+$regex = $regexes->getRegex($group, ITEMS_PER_PAGE, $offset);
+$count = $regexes->getCount($group);
+
+$page->smarty->assign([
+		'pagertotalitems'   => $count,
+		'pageroffset'       => $offset,
+		'pageritemsperpage' => ITEMS_PER_PAGE,
+		'regex'             => $regex,
+		'pagerquerybase'    => (WWW_TOP . "/category_regexes-list.php?" . $group . "offset="),
+		'pager'             => $page->smarty->fetch("pager.tpl")
+	]
+);
+
+$page->content = $page->smarty->fetch('category_regexes-list.tpl');
+$page->render();

--- a/www/themes_shared/scripts/utils-admin.js
+++ b/www/themes_shared/scripts/utils-admin.js
@@ -583,6 +583,30 @@ function ajax_binaryblacklist_delete(id)
 }
 
 /**
+ * ajax_category_regex_delete()
+ *
+ * @param id        binary id
+ */
+function ajax_category_regex_delete(id)
+{
+    // no caching of results
+    var rand_no = Math.random();
+    $.ajax({
+        url       : WWW_TOP + '/admin/ajax.php?action=category_regex_delete&rand=' + rand_no,
+        data      : { row_id: id},
+        dataType  : "html",
+        success   : function(data)
+        {
+            $('div#message').html(data);
+            $('div#message').show('fast', function() {});
+            $('#row-'+id).fadeOut(2000);
+            $('#message').fadeOut(5000);
+        },
+        error: function(xhr,err,e) { alert( "Error in ajax_category_regex_delete: " + err ); }
+    });
+}
+
+/**
  * ajax_collection_regex_delete()
  *
  * @param id        binary id

--- a/www/themes_shared/templates/admin/adminmenu.tpl
+++ b/www/themes_shared/templates/admin/adminmenu.tpl
@@ -14,6 +14,13 @@
 								<li class="last"><a href="{$smarty.const.WWW_TOP}/binaryblacklist-list.php">View</a></li>
 							</ul>
 						</li>
+						<li class="has-sub"><a href="#">Categorization</a>
+							<ul>
+								<li><a href="{$smarty.const.WWW_TOP}/category_regexes-edit.php?action=add">Add</a></li>
+								<li><a href="{$smarty.const.WWW_TOP}/category_regexes-test.php?action=add">Test</a></li>
+								<li class="last"><a href="{$smarty.const.WWW_TOP}/category_regexes-list.php">View</a></li>
+							</ul>
+						</li>
 						<li class="has-sub"><a href="#">Collections</a>
 							<ul>
 								<li><a href="{$smarty.const.WWW_TOP}/collection_regexes-edit.php?action=add">Add</a></li>

--- a/www/themes_shared/templates/admin/adminmenu.tpl
+++ b/www/themes_shared/templates/admin/adminmenu.tpl
@@ -17,7 +17,6 @@
 						<li class="has-sub"><a href="#">Categorization</a>
 							<ul>
 								<li><a href="{$smarty.const.WWW_TOP}/category_regexes-edit.php?action=add">Add</a></li>
-								<li><a href="{$smarty.const.WWW_TOP}/category_regexes-test.php?action=add">Test</a></li>
 								<li class="last"><a href="{$smarty.const.WWW_TOP}/category_regexes-list.php">View</a></li>
 							</ul>
 						</li>

--- a/www/themes_shared/templates/admin/category_regexes-edit.tpl
+++ b/www/themes_shared/templates/admin/category_regexes-edit.tpl
@@ -1,0 +1,73 @@
+<h1>{$page->title}</h1>
+{if $error != ''}
+	<div class="error">{$error}</div>
+{/if}
+<form action="{$SCRIPT_NAME}?action=submit" method="POST">
+	<table class="input">
+		<tr>
+			<td><label for="group_regex">Group:</label></td>
+			<td>
+				<input type="hidden" name="id" value="{$regex.id}" />
+				<input type="text" id="group_regex" name="group_regex" value="{$regex.group_regex|escape:html}" />
+				<div class="hint">
+					Regex to match against a group or multiple groups.<br />
+					Delimiters are already added, and PCRE_CASELESS is added after for case insensitivity.
+					An example of matching a single group: alt\.binaries\.example<br />
+					An example of matching multiple groups: alt\.binaries.*
+				</div>
+			</td>
+		</tr>
+		<tr>
+			<td><label for="regex">Regex:</label></td>
+			<td>
+				<textarea id="regex" name="regex" >{$regex.regex|escape:html}</textarea>
+				<div class="hint">
+					Regex to use when categorizing releases.<br />
+					The regex delimiters are not added, you MUST add them. See <a href="http://php.net/manual/en/regexp.reference.delimiters.php">this</a> page.<br />
+					To make the regex case insensitive, add i after the last delimiter.<br />
+				</div>
+			</td>
+		</tr>
+		<tr>
+			<td><label for="description">Description:</label></td>
+			<td>
+				<textarea id="description" name="description" >{$regex.description|escape:html}</textarea>
+				<div class="hint">
+					Description for this regex.<br />
+					You can include an example usenet subject this regex would match on.
+				</div>
+			</td>
+		</tr>
+		<tr>
+			<td><label for="ordinal">Ordinal:</label></td>
+			<td>
+				<input class="ordinal" id="ordinal" name="ordinal" type="text" value="{$regex.ordinal}" />
+				<div class="hint">
+					The order to run this regex in.<br />
+					Must be a number, 0 or higher.<br />
+					If multiple regex have the same ordinal, MySQL will randomly sort them.
+				</div>
+			</td>
+		</tr>
+		<tr>
+			<td><label for="status">Active:</label></td>
+			<td>
+				{html_radios id="status" name='status' values=$status_ids output=$status_names selected=$regex.status separator='<br />'}
+				<div class="hint">Only active regex are used during the collection matching process.</div>
+			</td>
+		</tr>
+		<tr>
+			<td><label for="category_id">Category:</label></td>
+			<td>
+				{html_options id="category_id" name='category_id' values=$category_ids output=$category_names selected=$regex.category_id}
+				<div class="hint">Select a category which releases matched to this regex will go into.</div>
+			</td>
+		</tr>
+		<tr>
+			<td></td>
+			<td>
+				<input type="submit" value="Save" />
+			</td>
+		</tr>
+	</table>
+</form>

--- a/www/themes_shared/templates/admin/category_regexes-list.tpl
+++ b/www/themes_shared/templates/admin/category_regexes-list.tpl
@@ -1,0 +1,45 @@
+<h1>{$page->title}</h1>
+<p>This page lists regex used for categorizing releases.</p>
+<div id="message"></div>
+
+<form name="groupsearch" action="" style="margin-bottom:5px;">
+	<label for="group">Search a group:</label>
+	<input id="group" type="text" name="group" value="{$group}" size="15" />
+	&nbsp;&nbsp;
+	<input type="submit" value="Go" />
+</form>
+{if $regex}
+
+	<div>{$pager}</div>
+	<table style="margin-top:10px;" class="data Sortable highlight">
+		<tr>
+			<th style="width:20px;">id</th>
+			<th>group</th>
+			<th style="width:25px;">edit</th>
+			<th>description</th>
+			<th style="width:40px;">delete</th>
+			<th>ordinal</th>
+			<th>status</th>
+			<th>regex</th>
+			<th>category id</th>
+		</tr>
+		{foreach from=$regex item=row}
+			<tr id="row-{$row.id}" class="{cycle values=",alt"}">
+				<td>{$row.id}</td>
+				<td>{$row.group_regex}</td>
+				<td title="Edit this regex"><a href="{$smarty.const.WWW_TOP}/category_regexes-edit.php?id={$row.id}">Edit</a></td>
+				<td>{$row.description|truncate:50:"...":true}</td>
+				<td title="Delete this regex"><a href="javascript:ajax_category_regex_delete({$row.id})" onclick="return confirm('Are you sure? This will delete the regex from this list.');" >Delete</a></td>
+				<td>{$row.ordinal}</td>
+				{if $row.status==1}
+					<td style="color:#00CC66">Active</td>
+				{else}
+					<td style="color:#FF0000">Disabled</td>
+				{/if}
+				<td title="Edit this regex"><a href="{$smarty.const.WWW_TOP}/category_regexes-edit.php?id={$row.id}">{$row.regex|escape:html|truncate:50:"...":true}</a></td>
+				<td>{$row.category_id}</td>
+			</tr>
+		{/foreach}
+	</table>
+	<div style="margin-top: 15px">{$pager}</div>
+{/if}

--- a/www/themes_shared/templates/admin/category_regexes-list.tpl
+++ b/www/themes_shared/templates/admin/category_regexes-list.tpl
@@ -1,5 +1,7 @@
 <h1>{$page->title}</h1>
-<p>This page lists regex used for categorizing releases.</p>
+<p>This page lists regex used for categorizing releases.<br />
+	You can recategorize all releases by running misc/update/update_releases.php 6 true
+</p>
 <div id="message"></div>
 
 <form name="groupsearch" action="" style="margin-bottom:5px;">


### PR DESCRIPTION
Categorizing releases using regex stored in the DB.

Should give a decent speed up to already existing categorizing by caching the group names instead of hitting up the DB every release name.