### PR TITLE
Adding ReCaptcha support

### DIFF
--- a/libs/ReCaptcha/ReCaptcha.php
+++ b/libs/ReCaptcha/ReCaptcha.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * This is a PHP library that handles calling reCAPTCHA.
+ *
+ * @copyright Copyright (c) 2015, Google Inc.
+ * @link      http://www.google.com/recaptcha
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+namespace ReCaptcha;
+
+/**
+ * reCAPTCHA client.
+ */
+class ReCaptcha
+{
+    /**
+     * Version of this client library.
+     * @const string
+     */
+    const VERSION = 'php_1.1.1';
+
+    /**
+     * Shared secret for the site.
+     * @var type string
+     */
+    private $secret;
+
+    /**
+     * Method used to communicate  with service. Defaults to POST request.
+     * @var RequestMethod
+     */
+    private $requestMethod;
+
+    /**
+     * Create a configured instance to use the reCAPTCHA service.
+     *
+     * @param string $secret shared secret between site and reCAPTCHA server.
+     * @param RequestMethod $requestMethod method used to send the request. Defaults to POST.
+     */
+    public function __construct($secret, RequestMethod $requestMethod = null)
+    {
+        if (empty($secret)) {
+            throw new \RuntimeException('No secret provided');
+        }
+
+        if (!is_string($secret)) {
+            throw new \RuntimeException('The provided secret must be a string');
+        }
+
+        $this->secret = $secret;
+
+        if (!is_null($requestMethod)) {
+            $this->requestMethod = $requestMethod;
+        } else {
+            $this->requestMethod = new RequestMethod\Post();
+        }
+    }
+
+    /**
+     * Calls the reCAPTCHA siteverify API to verify whether the user passes
+     * CAPTCHA test.
+     *
+     * @param string $response The value of 'g-recaptcha-response' in the submitted form.
+     * @param string $remoteIp The end user's IP address.
+     * @return Response Response from the service.
+     */
+    public function verify($response, $remoteIp = null)
+    {
+        // Discard empty solution submissions
+        if (empty($response)) {
+            $recaptchaResponse = new Response(false, array('missing-input-response'));
+            return $recaptchaResponse;
+        }
+
+        $params = new RequestParameters($this->secret, $response, $remoteIp, self::VERSION);
+        $rawResponse = $this->requestMethod->submit($params);
+        return Response::fromJson($rawResponse);
+    }
+}

--- a/libs/ReCaptcha/RequestMethod.php
+++ b/libs/ReCaptcha/RequestMethod.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * This is a PHP library that handles calling reCAPTCHA.
+ *
+ * @copyright Copyright (c) 2015, Google Inc.
+ * @link      http://www.google.com/recaptcha
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+namespace ReCaptcha;
+
+/**
+ * Method used to send the request to the service.
+ */
+interface RequestMethod
+{
+
+    /**
+     * Submit the request with the specified parameters.
+     *
+     * @param RequestParameters $params Request parameters
+     * @return string Body of the reCAPTCHA response
+     */
+    public function submit(RequestParameters $params);
+}

--- a/libs/ReCaptcha/RequestMethod/Post.php
+++ b/libs/ReCaptcha/RequestMethod/Post.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * This is a PHP library that handles calling reCAPTCHA.
+ *
+ * @copyright Copyright (c) 2015, Google Inc.
+ * @link      http://www.google.com/recaptcha
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+namespace ReCaptcha\RequestMethod;
+
+use ReCaptcha\RequestMethod;
+use ReCaptcha\RequestParameters;
+
+/**
+ * Sends POST requests to the reCAPTCHA service.
+ */
+class Post implements RequestMethod
+{
+    /**
+     * URL to which requests are POSTed.
+     * @const string
+     */
+    const SITE_VERIFY_URL = 'https://www.google.com/recaptcha/api/siteverify';
+
+    /**
+     * Submit the POST request with the specified parameters.
+     *
+     * @param RequestParameters $params Request parameters
+     * @return string Body of the reCAPTCHA response
+     */
+    public function submit(RequestParameters $params)
+    {
+        /**
+         * PHP 5.6.0 changed the way you specify the peer name for SSL context options.
+         * Using "CN_name" will still work, but it will raise deprecated errors.
+         */
+        $peer_key = version_compare(PHP_VERSION, '5.6.0', '<') ? 'CN_name' : 'peer_name';
+        $options = array(
+            'http' => array(
+                'header' => "Content-type: application/x-www-form-urlencoded\r\n",
+                'method' => 'POST',
+                'content' => $params->toQueryString(),
+                // Force the peer to validate (not needed in 5.6.0+, but still works
+                'verify_peer' => true,
+                // Force the peer validation to use www.google.com
+                $peer_key => 'www.google.com',
+            ),
+        );
+        $context = stream_context_create($options);
+        return file_get_contents(self::SITE_VERIFY_URL, false, $context);
+    }
+}

--- a/libs/ReCaptcha/RequestMethod/Socket.php
+++ b/libs/ReCaptcha/RequestMethod/Socket.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * This is a PHP library that handles calling reCAPTCHA.
+ *
+ * @copyright Copyright (c) 2015, Google Inc.
+ * @link      http://www.google.com/recaptcha
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+namespace ReCaptcha\RequestMethod;
+
+/**
+ * Convenience wrapper around native socket and file functions to allow for
+ * mocking.
+ */
+class Socket
+{
+    private $handle = null;
+
+    /**
+     * fsockopen
+     *
+     * @see http://php.net/fsockopen
+     * @param string $hostname
+     * @param int $port
+     * @param int $errno
+     * @param string $errstr
+     * @param float $timeout
+     * @return resource
+     */
+    public function fsockopen($hostname, $port = -1, &$errno = 0, &$errstr = '', $timeout = null)
+    {
+        $this->handle = fsockopen($hostname, $port, $errno, $errstr, (is_null($timeout) ? ini_get("default_socket_timeout") : $timeout));
+
+        if ($this->handle != false && $errno === 0 && $errstr === '') {
+            return $this->handle;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * fwrite
+     *
+     * @see http://php.net/fwrite
+     * @param string $string
+     * @param int $length
+     * @return int | bool
+     */
+    public function fwrite($string, $length = null)
+    {
+        return fwrite($this->handle, $string, (is_null($length) ? strlen($string) : $length));
+    }
+
+    /**
+     * fgets
+     *
+     * @see http://php.net/fgets
+     * @param int $length
+     */
+    public function fgets($length = null)
+    {
+        return fgets($this->handle, $length);
+    }
+
+    /**
+     * feof
+     *
+     * @see http://php.net/feof
+     * @return bool
+     */
+    public function feof()
+    {
+        return feof($this->handle);
+    }
+
+    /**
+     * fclose
+     *
+     * @see http://php.net/fclose
+     * @return bool
+     */
+    public function fclose()
+    {
+        return fclose($this->handle);
+    }
+}

--- a/libs/ReCaptcha/RequestMethod/SocketPost.php
+++ b/libs/ReCaptcha/RequestMethod/SocketPost.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * This is a PHP library that handles calling reCAPTCHA.
+ *
+ * @copyright Copyright (c) 2015, Google Inc.
+ * @link      http://www.google.com/recaptcha
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+namespace ReCaptcha\RequestMethod;
+
+use ReCaptcha\RequestMethod;
+use ReCaptcha\RequestParameters;
+
+/**
+ * Sends a POST request to the reCAPTCHA service, but makes use of fsockopen()
+ * instead of get_file_contents(). This is to account for people who may be on
+ * servers where allow_furl_open is disabled.
+ */
+class SocketPost implements RequestMethod
+{
+    /**
+     * reCAPTCHA service host.
+     * @const string
+     */
+    const RECAPTCHA_HOST = 'www.google.com';
+
+    /**
+     * @const string reCAPTCHA service path
+     */
+    const SITE_VERIFY_PATH = '/recaptcha/api/siteverify';
+
+    /**
+     * @const string Bad request error
+     */
+    const BAD_REQUEST = '{"success": false, "error-codes": ["invalid-request"]}';
+
+    /**
+     * @const string Bad response error
+     */
+    const BAD_RESPONSE = '{"success": false, "error-codes": ["invalid-response"]}';
+
+    /**
+     * Socket to the reCAPTCHA service
+     * @var Socket
+     */
+    private $socket;
+
+    /**
+     * Constructor
+     *
+     * @param \ReCaptcha\RequestMethod\Socket $socket optional socket, injectable for testing
+     */
+    public function __construct(Socket $socket = null)
+    {
+        if (!is_null($socket)) {
+            $this->socket = $socket;
+        } else {
+            $this->socket = new Socket();
+        }
+    }
+
+    /**
+     * Submit the POST request with the specified parameters.
+     *
+     * @param RequestParameters $params Request parameters
+     * @return string Body of the reCAPTCHA response
+     */
+    public function submit(RequestParameters $params)
+    {
+        $errno = 0;
+        $errstr = '';
+
+        if ($this->socket->fsockopen('ssl://' . self::RECAPTCHA_HOST, 443, $errno, $errstr, 30) !== false) {
+            $content = $params->toQueryString();
+
+            $request = "POST " . self::SITE_VERIFY_PATH . " HTTP/1.1\r\n";
+            $request .= "Host: " . self::RECAPTCHA_HOST . "\r\n";
+            $request .= "Content-Type: application/x-www-form-urlencoded\r\n";
+            $request .= "Content-length: " . strlen($content) . "\r\n";
+            $request .= "Connection: close\r\n\r\n";
+            $request .= $content . "\r\n\r\n";
+
+            $this->socket->fwrite($request);
+            $response = '';
+
+            while (!$this->socket->feof()) {
+                $response .= $this->socket->fgets(4096);
+            }
+
+            $this->socket->fclose();
+
+            if (0 === strpos($response, 'HTTP/1.1 200 OK')) {
+                $parts = preg_split("#\n\s*\n#Uis", $response);
+                return $parts[1];
+            }
+
+            return self::BAD_RESPONSE;
+        }
+
+        return self::BAD_REQUEST;
+    }
+}

--- a/libs/ReCaptcha/RequestParameters.php
+++ b/libs/ReCaptcha/RequestParameters.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * This is a PHP library that handles calling reCAPTCHA.
+ *
+ * @copyright Copyright (c) 2015, Google Inc.
+ * @link      http://www.google.com/recaptcha
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+namespace ReCaptcha;
+
+/**
+ * Stores and formats the parameters for the request to the reCAPTCHA service.
+ */
+class RequestParameters
+{
+    /**
+     * Site secret.
+     * @var string
+     */
+    private $secret;
+
+    /**
+     * Form response.
+     * @var string
+     */
+    private $response;
+
+    /**
+     * Remote user's IP address.
+     * @var string
+     */
+    private $remoteIp;
+
+    /**
+     * Client version.
+     * @var string
+     */
+    private $version;
+
+    /**
+     * Initialise parameters.
+     *
+     * @param string $secret Site secret.
+     * @param string $response Value from g-captcha-response form field.
+     * @param string $remoteIp User's IP address.
+     * @param string $version Version of this client library.
+     */
+    public function __construct($secret, $response, $remoteIp = null, $version = null)
+    {
+        $this->secret = $secret;
+        $this->response = $response;
+        $this->remoteIp = $remoteIp;
+        $this->version = $version;
+    }
+
+    /**
+     * Array representation.
+     *
+     * @return array Array formatted parameters.
+     */
+    public function toArray()
+    {
+        $params = array('secret' => $this->secret, 'response' => $this->response);
+
+        if (!is_null($this->remoteIp)) {
+            $params['remoteip'] = $this->remoteIp;
+        }
+
+        if (!is_null($this->version)) {
+            $params['version'] = $this->version;
+        }
+
+        return $params;
+    }
+
+    /**
+     * Query string representation for HTTP request.
+     *
+     * @return string Query string formatted parameters.
+     */
+    public function toQueryString()
+    {
+        return http_build_query($this->toArray(), '', '&');
+    }
+}

--- a/libs/ReCaptcha/Response.php
+++ b/libs/ReCaptcha/Response.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * This is a PHP library that handles calling reCAPTCHA.
+ *
+ * @copyright Copyright (c) 2015, Google Inc.
+ * @link      http://www.google.com/recaptcha
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+namespace ReCaptcha;
+
+/**
+ * The response returned from the service.
+ */
+class Response
+{
+    /**
+     * Succes or failure.
+     * @var boolean
+     */
+    private $success = false;
+
+    /**
+     * Error code strings.
+     * @var array
+     */
+    private $errorCodes = array();
+
+    /**
+     * Build the response from the expected JSON returned by the service.
+     *
+     * @param string $json
+     * @return \ReCaptcha\Response
+     */
+    public static function fromJson($json)
+    {
+        $responseData = json_decode($json, true);
+
+        if (!$responseData) {
+            return new Response(false, array('invalid-json'));
+        }
+
+        if (isset($responseData['success']) && $responseData['success'] == true) {
+            return new Response(true);
+        }
+
+        if (isset($responseData['error-codes']) && is_array($responseData['error-codes'])) {
+            return new Response(false, $responseData['error-codes']);
+        }
+
+        return new Response(false);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param boolean $success
+     * @param array $errorCodes
+     */
+    public function __construct($success, array $errorCodes = array())
+    {
+        $this->success = $success;
+        $this->errorCodes = $errorCodes;
+    }
+
+    /**
+     * Is success?
+     *
+     * @return boolean
+     */
+    public function isSuccess()
+    {
+        return $this->success;
+    }
+
+    /**
+     * Get error codes.
+     *
+     * @return array
+     */
+    public function getErrorCodes()
+    {
+        return $this->errorCodes;
+    }
+}

--- a/nzedb/controllers/Captcha.php
+++ b/nzedb/controllers/Captcha.php
@@ -1,0 +1,200 @@
+<?php
+use \nzedb\db\Settings;
+
+
+class Captcha {
+	/**
+	 * @var \nzedb\db\Settings
+	 */
+	private $pdo;
+
+	/**
+	 * ReCaptcha Site Key from the
+	 * settings database.
+	 *
+	 * @var bool|string
+	 */
+	private $sitekey;
+
+	/**
+	 * ReCaptcha Secret Key from the
+	 * settings database.
+	 *
+	 * @var bool|string
+	 */
+	private $secretkey;
+
+	/**
+	 * ReCaptcha instance if enabled.
+	 *
+	 * @var \ReCaptcha\ReCaptcha
+	 */
+	private $recaptcha;
+
+
+	/**
+	 * Contains the error output if ReCaptcha
+	 * validation fails.
+	 *
+	 * @var string|bool
+	 */
+	private $error = false;
+
+
+	/**
+	 * List of page routes to apply the captcha.
+	 *
+	 * @todo Find a better way to enumerate this, I hate literals.
+	 * @var array
+	 */
+	private $captcha_pages = [
+		'login',
+		'register',
+		'contact-us',
+		'forgottenpassword'
+	];
+
+	/**
+	 * $_POST key for the user-supplied ReCaptcha response.
+	 */
+	const RECAPTCHA_POSTKEY = 'g-recaptcha-response';
+
+	/**
+	 * Error literal constants.
+	 */
+	const RECAPTCHA_ERROR_MISSING_SECRET 	= 'missing-input-secret';
+	const RECAPTCHA_ERROR_INVALID_SECRET 	= 'invalid-input-secret';
+	const RECAPTCHA_ERROR_MISSING_RESPONSE 	= 'missing-input-response';
+	const RECAPTCHA_ERROR_INVALID_RESPONSE 	= 'invalid-input-response';
+
+	/**
+	 * Construct.
+	 *
+	 * @param array $options Class instances.
+	 */
+	public function __construct(array $options = []) {
+		$defaults = [
+			'Settings' => null
+		];
+		$options += $defaults;
+
+		$this->pdo = ($options['Settings'] instanceof Settings ? $options['Settings'] : new Settings());
+	}
+
+	/**
+	 * If site admin setup keys properly,
+	 * allow display of recaptcha.
+	 *
+	 * @param string|bool $page
+	 * @return bool
+	 */
+	public function shouldDisplay($page = false) {
+		if ($page !== false) {
+			if (in_array($page, $this->captcha_pages) && $this->_bootstrapCaptcha()) {
+				return true;
+			}
+		} elseif ($this->_bootstrapCaptcha()) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Return formatted error messages.
+	 *
+	 * @return string
+	 */
+	public function getError() {
+		return $this->error;
+	}
+
+	/**
+	 * Return sitekey for captcha html display.
+	 *
+	 * @return bool|string
+	 */
+	public function getSiteKey() {
+		return $this->sitekey;
+	}
+
+	/**
+	 * Process the submitted captcha and validate.
+	 *
+	 * @param array $response
+	 * @param string $ip
+	 * @return bool
+	 */
+	public function processCaptcha($response, $ip) {
+		if (isset($response[self::RECAPTCHA_POSTKEY])) {
+			$post_response = $response[self::RECAPTCHA_POSTKEY];
+		} else {
+			$post_response = '';
+		}
+
+		$verify_response = $this->recaptcha->verify($post_response, $ip);
+
+		if (!$verify_response->isSuccess()) {
+			$this->_handleErrors($verify_response->getErrorCodes());
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Build formatted error string for output using
+	 * Google's reCaptcha error codes.
+	 *
+	 * @param array $codes
+	 */
+	private function _handleErrors($codes) {
+		$rc_error = 'ReCaptcha Failed: ';
+
+		foreach ($codes as $c) {
+			switch($c) {
+				case self::RECAPTCHA_ERROR_MISSING_SECRET:
+					$rc_error .= 'Missing Secret Key';
+					break;
+				case self::RECAPTCHA_ERROR_INVALID_SECRET:
+					$rc_error .= 'Invalid Secret Key';
+					break;
+				case self::RECAPTCHA_ERROR_MISSING_RESPONSE:
+					$rc_error .= 'No Response!';
+					break;
+				case self::RECAPTCHA_ERROR_INVALID_RESPONSE:
+					$rc_error .= 'Invalid response! You are a bot!';
+					break;
+				default:
+					$rc_error .= 'Unknown Error!';
+			}
+		}
+
+		$this->error = $rc_error;
+	}
+
+	/**
+	 * Instantiate the ReCaptcha library and store it.
+	 * Return bool on success/failure.
+	 *
+	 * @return bool
+	 */
+	private function _bootstrapCaptcha() {
+		if ($this->recaptcha instanceof \ReCaptcha\ReCaptcha) {
+			return true;
+		}
+
+		$this->sitekey = $this->pdo->getSetting('recaptchasitekey');
+		$this->secretkey = $this->pdo->getSetting('recaptchasecretkey');
+
+		if ($this->sitekey != false && $this->sitekey != '') {
+			if ($this->secretkey != false && $this->secretkey != '') {
+				$this->recaptcha = new \ReCaptcha\ReCaptcha($this->secretkey);
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+}

--- a/resources/db/patches/mysql/+1~settings.sql
+++ b/resources/db/patches/mysql/+1~settings.sql
@@ -1,0 +1,2 @@
+INSERT INTO settings (section, name, hint, setting) VALUES ('APIs', 'recaptchasitekey', 'ReCaptcha SiteKey for generating the captcha block for input forms.', 'recaptchasitekey');
+INSERT INTO settings (section, name, hint, setting) VALUES ('APIs', 'recaptchasecretkey', 'ReCaptcha SecretKey for verifying submitted captcha results.', 'recaptchasecretkey');

--- a/resources/db/schema/data/10-settings.tsv
+++ b/resources/db/schema/data/10-settings.tsv
@@ -107,6 +107,8 @@ APIs		fanarttvkey		The Fanart.tv api key. Used for Fanart.tv lookups. Fanart.tv 
 APIs		rottentomatokey	qxbxyngtujprvw7jxam2m6na	The api key used for access to rotten tomatoes.	rottentomatokey
 APIs		tmdbkey	9a4e16adddcd1e86da19bcaf5ff3c2a3	The API key used for access to TMDb.	tmdbkey
 APIs		trakttvkey		The trakt.tv api key. Used for movie and tv lookups.	trakttvkey
+APIs		recaptchasitekey		ReCaptcha SiteKey for generating the captcha block for input forms.	recaptchasitekey
+APIs		recaptchasecretkey		ReCaptcha SecretKey for verifying submitted captcha results.	recaptchasecretkey
 APIs	APIKeys	section-label	3<sup>rd.</sup> Party API Keys		""
 apps	indexer	magic_file_path		Path to magic number database. Windows&apos; users should set this if they have installed GNUWin &lsquo;file&rsquo;. *nix users can optionally set this to a file of their choice.	magic_file_path
 apps		7zippath		The path to the 7za (7zip command line in windows) binary, used for grabbing nfos from compressed zip files. Use forward slashes in windows c:/path/to/7z.exe	zippath

--- a/www/pages/BasePage.php
+++ b/www/pages/BasePage.php
@@ -60,6 +60,13 @@ class BasePage
 	public $https = false;
 
 	/**
+	 * Public access to Captcha object for error checking.
+	 *
+	 * @var Captcha
+	 */
+	public $captcha;
+
+	/**
 	 * Set up session / smarty / user variables.
 	 */
 	public function __construct()
@@ -147,10 +154,41 @@ class BasePage
 			$this->smarty->assign('isadmin', 'false');
 			$this->smarty->assign('ismod', 'false');
 			$this->smarty->assign('loggedin', 'false');
+
+			$this->handleCaptcha();
 		}
 
 		$this->smarty->assign('site', $this->settings);
 		$this->smarty->assign('page', $this);
+	}
+
+	/**
+	 * Allow display on pages that require captcha
+	 * and handle captcha responses.
+	 *
+	 * @notes Optimized for speed over code brevity since it's
+	 * executed on every singe page.
+	 * Instantiating Captcha() doesn't initialize the underlying libraries.
+	 * shouldDisplay() does it if applicable.
+	 */
+	private function handleCaptcha() {
+		$this->captcha = new Captcha(['Settings' => $this->settings]);
+
+		if ($this->captcha->shouldDisplay($this->page)) {
+			$this->smarty->assign('showCaptcha', true);
+			$this->smarty->assign('sitekey', $this->captcha->getSiteKey());
+
+			if ($this->isPostBack()) {
+				if (!$this->captcha->processCaptcha($_POST, $_SERVER['REMOTE_ADDR'])) {
+					$this->smarty->assign('error', $this->captcha->getError());
+				}
+				//Delete this key after using so it doesn't interfere with normal $_POST
+				//processing. (i.e. contact-us)
+				unset($_POST[Captcha::RECAPTCHA_POSTKEY]);
+			}
+		} else {
+			$this->smarty->assign('showCaptcha', false);
+		}
 	}
 
 	/**

--- a/www/pages/contact-us.php
+++ b/www/pages/contact-us.php
@@ -3,24 +3,29 @@
 use \nzedb\utility\Utility;
 
 if (isset($_POST["useremail"])) {
-	// Send the contact info and report back to user.
-	$email = $_POST["useremail"];
-	$mailto = $page->settings->getSetting('email');
 
-	$mailsubj = "Contact Form Submitted";
-	$mailbody = "Values submitted from contact form:<br/>";
+	if ($page->captcha->getError() === false) {
 
-	while (list ($key, $val) = each($_POST)) {
-		if ($key != "submit") {
-			$mailbody .= "$key : $val<br />\r\n";
+		// Send the contact info and report back to user.
+		$email = $_POST["useremail"];
+		$mailto = $page->settings->getSetting('email');
+
+		$mailsubj = "Contact Form Submitted";
+		$mailbody = "Values submitted from contact form:<br/>";
+
+		//@TODO take this loop out, it's not safe.
+		while (list ($key, $val) = each($_POST)) {
+			if ($key != 'submit') {
+				$mailbody .= "$key : $val<br/>";
+			}
 		}
-	}
 
-	if (!preg_match("/\n/i", $_POST["useremail"])) {
-		Utility::sendEmail($mailto, $mailsubj, $mailbody, $email);
-	}
+		if (!preg_match("/\n/i", $_POST["useremail"])) {
+			Utility::sendEmail($mailto, $mailsubj, $mailbody, $email);
+		}
 
-	$page->smarty->assign("msg", "<h2 style='text-align:center;'>Thank you for getting in touch with " . $page->settings->getSetting('title') . ".</h2>");
+		$page->smarty->assign("msg", "<h2 style='text-align:center;'>Thank you for getting in touch with " . $page->settings->getSetting('title') . ".</h2>");
+	}
 }
 
 $page->title = "Contact " . $page->settings->getSetting('title');

--- a/www/pages/forgottenpassword.php
+++ b/www/pages/forgottenpassword.php
@@ -37,29 +37,30 @@ switch ($action) {
 
 		break;
 	case 'submit':
+		if ($page->captcha->getError() === false) {
+			$page->smarty->assign('email', $_POST['email']);
 
-		$page->smarty->assign('email', $_POST['email']);
-
-		if ($_POST['email'] == "") {
-			$page->smarty->assign('error', "Missing Email");
-		} else {
-			// Check users exists and send an email.
-			$ret = $page->users->getByEmail($_POST['email']);
-			if (!$ret) {
-				$page->smarty->assign('sent', "true");
-				break;
+			if ($_POST['email'] == "") {
+				$page->smarty->assign('error', "Missing Email");
 			} else {
-				// Generate a forgottenpassword guid, store it in the user table.
-				$guid = md5(uniqid());
-				$page->users->updatePassResetGuid($ret["id"], $guid);
+				// Check users exists and send an email.
+				$ret = $page->users->getByEmail($_POST['email']);
+				if (!$ret) {
+					$page->smarty->assign('sent', "true");
+					break;
+				} else {
+					// Generate a forgottenpassword guid, store it in the user table.
+					$guid = md5(uniqid());
+					$page->users->updatePassResetGuid($ret["id"], $guid);
 
-				// Send the email
-				$to = $ret["email"];
-				$subject = $page->settings->getSetting('title') . " Forgotten Password Request";
-				$contents = "Someone has requested a password reset for this email address.<br>To reset the password use <a href=\"" . $page->serverurl . "forgottenpassword?action=reset&guid=$guid\">this link</a>\n";
-				$page->smarty->assign('sent', "true");
-				nzedb\utility\Utility::sendEmail($to, $subject, $contents, $page->settings->getSetting('email'));
-				break;
+					// Send the email
+					$to = $ret["email"];
+					$subject = $page->settings->getSetting('title') . " Forgotten Password Request";
+					$contents = "Someone has requested a password reset for this email address.<br>To reset the password use <a href=\"" . $page->serverurl . "forgottenpassword?action=reset&guid=$guid\">this link</a>\n";
+					$page->smarty->assign('sent', "true");
+					nzedb\utility\Utility::sendEmail($to, $subject, $contents, $page->settings->getSetting('email'));
+					break;
+				}
 			}
 		}
 		break;

--- a/www/pages/login.php
+++ b/www/pages/login.php
@@ -2,7 +2,7 @@
 if ($page->isPostBack()) {
 	if (!isset($_POST["username"]) || !isset($_POST["password"])) {
 		$page->smarty->assign('error', "Please enter your username and password.");
-	} else {
+	} elseif ($page->captcha->getError() === false) {
 		$username = htmlspecialchars($_POST["username"]);
 		$page->smarty->assign('username', $username);
 		$logging = new Logging(['Settings' => $page->settings]);

--- a/www/pages/register.php
+++ b/www/pages/register.php
@@ -21,58 +21,67 @@ if ($showregister == 0) {
 } else {
 	$action = isset($_REQUEST['action']) ? $_REQUEST['action'] : 'view';
 
+	//Be sure to persist the invite code in the event of multiple form submissions. (errors)
+	if (isset($_REQUEST['invitecode'])) {
+		$page->smarty->assign('invite_code_query', '&invitecode='.htmlspecialchars($_REQUEST["invitecode"]));
+	} else {
+		$page->smarty->assign('invite_code_query', '');
+	}
+
 	switch ($action) {
 		case 'submit':
-			$firstName = (isset($_POST['firstname']) ? htmlspecialchars($_POST['firstname']) : '');
-			$lastName = (isset($_POST['lastname']) ? htmlspecialchars($_POST['lastname']) : '');
-			$username = htmlspecialchars($_POST['username']);
-			$password = htmlspecialchars($_POST['password']);
-			$confirmpassword = htmlspecialchars($_POST['confirmpassword']);
-			$email = htmlspecialchars($_POST['email']);
-			$invitecode = htmlspecialchars($_POST["invitecode"]);
+			if ($page->captcha->getError() === false) {
+				$firstName = (isset($_POST['firstname']) ? htmlspecialchars($_POST['firstname']) : '');
+				$lastName = (isset($_POST['lastname']) ? htmlspecialchars($_POST['lastname']) : '');
+				$username = htmlspecialchars($_POST['username']);
+				$password = htmlspecialchars($_POST['password']);
+				$confirmpassword = htmlspecialchars($_POST['confirmpassword']);
+				$email = htmlspecialchars($_POST['email']);
+				$invitecode = htmlspecialchars($_POST["invitecode"]);
 
-			$page->smarty->assign('username', $username);
-			$page->smarty->assign('firstname', $firstName);
-			$page->smarty->assign('lastname', $lastName);
-			$page->smarty->assign('password', $password);
-			$page->smarty->assign('confirmpassword', $confirmpassword);
-			$page->smarty->assign('email', $email);
-			$page->smarty->assign('invitecode', $invitecode);
+				$page->smarty->assign('username', $username);
+				$page->smarty->assign('firstname', $firstName);
+				$page->smarty->assign('lastname', $lastName);
+				$page->smarty->assign('password', $password);
+				$page->smarty->assign('confirmpassword', $confirmpassword);
+				$page->smarty->assign('email', $email);
+				$page->smarty->assign('invitecode', $invitecode);
 
-			// Check uname/email isn't in use, password valid. If all good create new user account and redirect back to home page.
-			if ($password != $confirmpassword) {
-				$page->smarty->assign('error', "Password Mismatch");
-			} else {
-				// Get the default user role.
-				$userdefault = $page->users->getDefaultRole();
-
-				$ret = $page->users->signUp($username, $firstname, $lastname, $password, $email, $_SERVER['REMOTE_ADDR'], $userdefault['id'], $userdefault['defaultinvites'], $invitecode);
-				if ($ret > 0) {
-					$page->users->login($ret, $_SERVER['REMOTE_ADDR']);
-					header("Location: " . WWW_TOP . "/");
+				// Check uname/email isn't in use, password valid. If all good create new user account and redirect back to home page.
+				if ($password != $confirmpassword) {
+					$page->smarty->assign('error', "Password Mismatch");
 				} else {
-					switch ($ret) {
-						case Users::ERR_SIGNUP_BADUNAME:
-							$page->smarty->assign('error', "Your username must be at least five characters.");
-							break;
-						case Users::ERR_SIGNUP_BADPASS:
-							$page->smarty->assign('error', "Your password must be longer than eight characters.");
-							break;
-						case Users::ERR_SIGNUP_BADEMAIL:
-							$page->smarty->assign('error', "Your email is not a valid format.");
-							break;
-						case Users::ERR_SIGNUP_UNAMEINUSE:
-							$page->smarty->assign('error', "Sorry, the username is already taken.");
-							break;
-						case Users::ERR_SIGNUP_EMAILINUSE:
-							$page->smarty->assign('error', "Sorry, the email is already in use.");
-							break;
-						case Users::ERR_SIGNUP_BADINVITECODE:
-							$page->smarty->assign('error', "Sorry, the invite code is old or has been used.");
-							break;
-						default:
-							$page->smarty->assign('error', "Failed to register.");
-							break;
+					// Get the default user role.
+					$userdefault = $page->users->getDefaultRole();
+
+					$ret = $page->users->signUp($username, $firstname, $lastname, $password, $email, $_SERVER['REMOTE_ADDR'], $userdefault['id'], $userdefault['defaultinvites'], $invitecode);
+					if ($ret > 0) {
+						$page->users->login($ret, $_SERVER['REMOTE_ADDR']);
+						header("Location: " . WWW_TOP . "/");
+					} else {
+						switch ($ret) {
+							case Users::ERR_SIGNUP_BADUNAME:
+								$page->smarty->assign('error', "Your username must be at least five characters.");
+								break;
+							case Users::ERR_SIGNUP_BADPASS:
+								$page->smarty->assign('error', "Your password must be longer than eight characters.");
+								break;
+							case Users::ERR_SIGNUP_BADEMAIL:
+								$page->smarty->assign('error', "Your email is not a valid format.");
+								break;
+							case Users::ERR_SIGNUP_UNAMEINUSE:
+								$page->smarty->assign('error', "Sorry, the username is already taken.");
+								break;
+							case Users::ERR_SIGNUP_EMAILINUSE:
+								$page->smarty->assign('error', "Sorry, the email is already in use.");
+								break;
+							case Users::ERR_SIGNUP_BADINVITECODE:
+								$page->smarty->assign('error', "Sorry, the invite code is old or has been used.");
+								break;
+							default:
+								$page->smarty->assign('error', "Failed to register.");
+								break;
+						}
 					}
 				}
 			}

--- a/www/themes/Default/templates/frontend/captcha.tpl
+++ b/www/themes/Default/templates/frontend/captcha.tpl
@@ -1,0 +1,7 @@
+{if $showCaptcha == true}
+	<div class="g-recaptcha" data-sitekey="{$sitekey}"></div>
+	<script type="text/javascript"
+			src="https://www.google.com/recaptcha/api.js?hl=en">
+	</script>
+	<br/>
+{/if}

--- a/www/themes/Default/templates/frontend/contact.tpl
+++ b/www/themes/Default/templates/frontend/contact.tpl
@@ -34,6 +34,7 @@
 			<tr>
 				<td></td>
 				<td>
+					{$page->smarty->fetch('captcha.tpl')}
 					<input type="submit" value="Submit" />
 				</td>
 			</tr>

--- a/www/themes/Default/templates/frontend/forgottenpassword.tpl
+++ b/www/themes/Default/templates/frontend/forgottenpassword.tpl
@@ -18,7 +18,7 @@
 					<input id="email" autocomplete="off" name="email" value="{$email}" type="email"/>
 				</td>
 			</tr>
-			<tr><th></th><td><input type="submit" value="Request Password Reset" /><div style="float:right;" class="hint"><em>*</em> Indicates mandatory field.</div></td></tr>
+			<tr><th></th><td>{$page->smarty->fetch('captcha.tpl')}<input type="submit" value="Request Password Reset" /><div style="float:right;" class="hint"><em>*</em> Indicates mandatory field.</div></td></tr>
 		</table>
 	</form>
 {elseif $sent != ''}

--- a/www/themes/Default/templates/frontend/login.tpl
+++ b/www/themes/Default/templates/frontend/login.tpl
@@ -17,7 +17,7 @@
 				<input style="width:150px;" id="password" name="password" type="password"/>
 			</td></tr>
 		<tr><th><label for="rememberme">Remember Me:</label></th><td><input id="rememberme" {if $rememberme == 1}checked="checked"{/if} name="rememberme" type="checkbox"/></td>
-		<tr><th></th><td><input type="submit" value="Login"/></td></tr>
+		<tr><th></th><td>{$page->smarty->fetch('captcha.tpl')}<input type="submit" value="Login"/></td></tr>
 	</table>
 </form>
 <br/>

--- a/www/themes/Default/templates/frontend/register.tpl
+++ b/www/themes/Default/templates/frontend/register.tpl
@@ -6,7 +6,7 @@
 {/if}
 
 {if $showregister != "0"}
-	<form method="post" action="register?action=submit">
+	<form method="post" action="register?action=submit{$invite_code_query}">
 
 		<table style="width:500px;" class="data">
 			<tr><th width="75px;"><label for="username">Username:</label> <em>*</em></th>
@@ -39,7 +39,7 @@
 		</table>
 
 		<table style="width:500px; margin-top:10px;" class="data">
-			<tr><th width="75px;"></th><td><input type="submit" value="Register"/><div style="float:right;" class="hint"><em>*</em> Indicates mandatory field.</div></td></tr>
+			<tr><th width="75px;"></th><td>{$page->smarty->fetch('captcha.tpl')}<input type="submit" value="Register"/><div style="float:right;" class="hint"><em>*</em> Indicates mandatory field.</div></td></tr>
 		</table>
 
 	</form>

--- a/www/themes/alpha/templates/frontend/contact.tpl
+++ b/www/themes/alpha/templates/frontend/contact.tpl
@@ -22,6 +22,7 @@
 							<label for="comment">Comment or Review</label>
 							<textarea rows="3" id="comment" class="form-control" name="comment" value=""></textarea>
 						</div>
+						{$page->smarty->fetch('captcha.tpl')}
 						<div class="form-group">
 							<button id="submit" name="submit" class="btn btn-success">Submit</button>
 						</div>

--- a/www/themes/alpha/templates/frontend/forgottenpassword.tpl
+++ b/www/themes/alpha/templates/frontend/forgottenpassword.tpl
@@ -16,6 +16,7 @@
 						<label class="sr-only" for="email">E-mail Address</label>
 						<input type="email" class="form-control" placeholder="E-mail Address" id="email" value="{$email}" name="email">
 					</div>
+					{$page->smarty->fetch('captcha.tpl')}
 					<button class="btn btn-success" type="submit" value="Request Password Reset">Request Password Reset</button>
 				</form>
 			</div>

--- a/www/themes/alpha/templates/frontend/login.tpl
+++ b/www/themes/alpha/templates/frontend/login.tpl
@@ -20,6 +20,7 @@
 						<input type="checkbox" id="rememberme" {if $rememberme == 1}checked="checked" {/if}name="rememberme"> Remember me
 					</label>
 				</div>
+				{$page->smarty->fetch('captcha.tpl')}
 				<button class="btn btn-success" type="submit" value="Login">Login</button>
 				<a class="text-right" href="{$smarty.const.WWW_TOP}/forgottenpassword"><button class="btn btn-link" type="button">Forgotten your password?</button></a>
 			</form>

--- a/www/themes/alpha/templates/frontend/register.tpl
+++ b/www/themes/alpha/templates/frontend/register.tpl
@@ -6,7 +6,7 @@
 	<div class="container">
 	<div class="col-sm-6 col-sm-offset-3">
 		<div class="well">
-			<form class="form-signin" action="register?action=submit" method="post">
+			<form class="form-signin" action="register?action=submit{$invite_code_query}" method="post">
 				<h2 class="form-signin-heading">Please Register</h2>
 				<div class="form-group">
 					<label class="sr-only" for="username">Username</label>
@@ -41,6 +41,7 @@
 					<label class="sr-only" for="email">E-mail Address</label>
 					<input type="email" class="form-control" placeholder="Email" autocomplete="off" id="email" name="email" value="{$email}">
 				</div>
+				{$page->smarty->fetch('captcha.tpl')}
 				<input type="hidden" class="form-control" id="invitecode" name="invitecode" value="{$invitecode|escape:html_all}">
 				<button class="btn btn-default" type="submit" value="Register">Register</button>
 			</form>

--- a/www/themes/light/templates/frontend/forgottenpassword.tpl
+++ b/www/themes/light/templates/frontend/forgottenpassword.tpl
@@ -18,7 +18,7 @@
                     <input id="email" autocomplete="off" name="email" value="{$email}" type="email"/>
                 </td>
             </tr>
-            <tr><th></th><td><input class="rndbtn" type="submit" value="Request Password Reset" /><br /><br /><div style="float:left;" class="hint"><em>*</em> Indicates mandatory field.</div></td></tr>
+            <tr><th></th><td>{$page->smarty->fetch('captcha.tpl')}<input class="rndbtn" type="submit" value="Request Password Reset" /><br /><br /><div style="float:left;" class="hint"><em>*</em> Indicates mandatory field.</div></td></tr>
         </table>
     </form>
 {elseif $sent != ''}

--- a/www/themes/light/templates/frontend/login.tpl
+++ b/www/themes/light/templates/frontend/login.tpl
@@ -17,7 +17,7 @@
                 <input style="width:150px;" id="password" name="password" type="password"/>
             </td></tr>
         <tr><th><label for="rememberme">Remember Me:</label></th><td><input id="rememberme" {if $rememberme == 1}checked="checked"{/if} name="rememberme" type="checkbox"/></td></tr>
-        <tr><th></th><td><input class="rndbtn" type="submit" value="Login"/></td></tr>
+        <tr><th></th><td>{$page->smarty->fetch('captcha.tpl')}<input class="rndbtn" type="submit" value="Login"/></td></tr>
     </table>
 </form>
 <br/>

--- a/www/themes/light/templates/frontend/register.tpl
+++ b/www/themes/light/templates/frontend/register.tpl
@@ -3,7 +3,7 @@
 	<div class="error">{$error}</div>
 {/if}
 {if $showregister != "0"}
-	<form method="post" action="register?action=submit">
+	<form method="post" action="register?action=submit{$invite_code_query}">
 		<table style="width:500px;" class="data">
 			<tr><th width="75px;"><label for="username">Username: <em>*</em></label></th>
 				<td>
@@ -34,7 +34,7 @@
 			<tr><th><label for="email">Email: <em>*</em></label></th><td><input autocomplete="off" id="email" name="email" value="{$email}" type="text" /></td></tr>
 		</table>
 		<table style="width:500px; margin-top:10px;" class="data">
-			<tr><th width="75px;"></th><td><input class="rndbtn" type="submit" value="Register"/><br /><br /><div style="float:left;" class="hint"><em>*</em> Indicates mandatory field.</div></td></tr>
+			<tr><th width="75px;"></th><td>{$page->smarty->fetch('captcha.tpl')}<input class="rndbtn" type="submit" value="Register"/><br /><br /><div style="float:left;" class="hint"><em>*</em> Indicates mandatory field.</div></td></tr>
 		</table>
 	</form>
 {/if}

--- a/www/themes_shared/templates/admin/site-edit.tpl
+++ b/www/themes_shared/templates/admin/site-edit.tpl
@@ -317,6 +317,23 @@
 					</div>
 				</td>
 			</tr>
+			<tr>
+				<td style="width:180px;"><label for="recaptchasitekey">ReCaptcha Site Key:</label></td>
+				<td>
+					<input id="recaptchasitekey" class="long" name="recaptchasitekey" type="text" value="{$site->recaptchasitekey}"/>
+					<div class="hint">Register your application with ReCaptcha <a href="https://www.google.com/recaptcha" target="_blank">here</a>
+						to get your site and secret keys. Adding these keys will place ReCaptch's on all user-input forms. (Login, Register, Contact Us, Forgot Password)
+					</div>
+				</td>
+			</tr>
+			<tr>
+				<td style="width:180px;"><label for="recaptchasecretkey">ReCaptcha Secret key:</label></td>
+				<td>
+					<input id="recaptchasecretkey" class="long" name="recaptchasecretkey" type="text" value="{$site->recaptchasecretkey}"/>
+					<div class="hint">This is the required secret key for ReCaptcha to work, see the above setting hint for further information.
+					</div>
+				</td>
+			</tr>
 		</table>
 	</fieldset>
 


### PR DESCRIPTION
If site-admin adds ReCaptcha site and secret keys in the admin->site_edit page, captcha's will display on every page that accepts unauthenticated user input (login, register, contact, forgottenpassword). If one or both of the keys are empty nothing is displayed, no errors. Seamless "failure". 

This PR includes the ReCaptcha PHP library by Google as well as a wrapper class, Captcha() that integrates with the site. There were many ways to accomplish this but I tried to stick to DRY as much as possible which is why I opted to process everything in BasePage instead of copying and pasting the same code in each of the 4 pages. It adds some slight overhead to every page load but only inasmuch as instantiating an empty class. 

You'll see some type checking going on (which I know we use sparingly) but I think it's justified. As you can see, $captcha->getError() outputs bool false if no errors. If something should happen and a blank error comes through (like if they update their error messages and we don't support it) It should still display an error and not allow the page transaction through. If you guys think otherwise, I can change it.

I tried to implement this in a way that affected as few pages as possible. It still requires a line added to each page and template but I didn't see a way to do it otherwise for the same amount of effort.

Let me know if anything needs to be added or changed.

Also, FWIW I did test with every single template and they all work as expected both with and without the recaptcha enabled.