### PR TITLE
Do urldecode before working on 'cat' 

### DIFF
--- a/www/pages/api.php
+++ b/www/pages/api.php
@@ -367,10 +367,10 @@ function categoryID()
 {
 	$categoryID[] = -1;
 	if (isset($_GET['cat'])) {
-		$categoryIDs = $_GET['cat'];
+		$categoryIDs = urldecode($_GET['cat']);
 		// Append Web-DL category ID if HD present for SickBeard / NZBDrone compatibility.
-		if (strpos($_GET['cat'], (string)Category::CAT_TV_HD) !== false &&
-			strpos($_GET['cat'], (string)Category::CAT_TV_WEBDL) === false) {
+		if (strpos(urldecode($_GET['cat']), (string)Category::CAT_TV_HD) !== false &&
+			strpos(urldecode($_GET['cat']), (string)Category::CAT_TV_WEBDL) === false) {
 			$categoryIDs .= (',' . Category::CAT_TV_WEBDL);
 		}
 		$categoryID = explode(',', $categoryIDs);


### PR DESCRIPTION
For me the commas were still urlencoded when hitting the api, and adding these urldecode calls fixed it. Using SickRage as client.