### PR TITLE
Implement local temporary caching for Amazon lookup failures.

### DIFF
--- a/nzedb/Books.php
+++ b/nzedb/Books.php
@@ -61,6 +61,12 @@ class Books
 	public $renamed;
 
 	/**
+	 * Store names of failed Amazon lookup items
+	 * @var array
+	 */
+	public $failCache;
+
+	/**
 	 * @param array $options Class instances / Echo to cli.
 	 */
 	public function __construct(array $options = [])

--- a/nzedb/Console.php
+++ b/nzedb/Console.php
@@ -57,6 +57,12 @@ class Console
 	public $renamed;
 
 	/**
+	 * Store names of failed Amazon lookup items
+	 * @var array
+	 */
+	public $failCache;
+
+	/**
 	 * @param array $options Class instances / Echo to cli.
 	 */
 	public function __construct(array $options = [])

--- a/nzedb/Console.php
+++ b/nzedb/Console.php
@@ -81,6 +81,8 @@ class Console
 			$this->renamed = 'AND isrenamed = 1';
 		}
 		//$this->cleanconsole = ($this->pdo->getSetting('lookupgames') == 2) ? 'AND isrenamed = 1' : '';
+
+		$this->failCache = array();
 	}
 
 	public function getConsoleInfo($id)
@@ -725,9 +727,19 @@ class Console
 					// Check for existing console entry.
 					$gameCheck = $this->getConsoleInfoByName($gameInfo['title'], $gameInfo['platform']);
 
-					if ($gameCheck === false) {
+					if ($gameCheck === false && in_array($gameInfo['title'] . $gameInfo['platform'], $this->failCache)) {
+						// Lookup recently failed, no point trying again
+						if ($this->echooutput) {
+							$this->pdo->log->doEcho($this->pdo->log->headerOver('Cached previous failure. Skipping.') . PHP_EOL);
+						}
+						$gameId = -2;
+					} else if ($gameCheck === false) {
 						$gameId = $this->updateConsoleInfo($gameInfo);
 						$usedAmazon = true;
+						if ($gameId === false) {
+							$gameId = -2;
+							$this->failCache[] = $gameInfo['title'] . $gameInfo['platform'];
+						}
 					} else {
 						if ($this->echooutput) {
 							$this->pdo->log->doEcho(

--- a/nzedb/Music.php
+++ b/nzedb/Music.php
@@ -57,6 +57,12 @@ class Music
 	public $renamed;
 
 	/**
+	 * Store names of failed Amazon lookup items
+	 * @var array
+	 */
+	public $failCache;
+
+	/**
 	 * @param array $options Class instances/ echo to CLI.
 	 */
 	public function __construct(array $options = [])

--- a/nzedb/Music.php
+++ b/nzedb/Music.php
@@ -80,6 +80,8 @@ class Music
 		if ($this->pdo->getSetting('lookupmusic') == 2) {
 			$this->renamed = 'AND isrenamed = 1';
 		}
+
+		$this->failCache = array();
 	}
 
 	/**
@@ -630,11 +632,18 @@ class Music
 					// Do a local lookup first
 					$musicCheck = $this->getMusicInfoByName('', $album["name"]);
 
-					if ($musicCheck === false && $local === false) {
-						$albumId = $this->updateMusicInfo($album["name"], $album['year']);
+					if ($musicCheck === false && in_array($album['name'] . $album['year'], $this->failCache)) {
+						// Lookup recently failed, no point trying again
+						if ($this->echooutput) {
+							$this->pdo->log->doEcho($this->pdo->log->headerOver('Cached previous failure. Skipping.') . PHP_EOL);
+						}
+						$albumId = -2;
+					} else if ($musicCheck === false && $local === false) {
+						$albumId = $this->updateMusicInfo($album['name'], $album['year']);
 						$usedAmazon = true;
 						if ($albumId === false) {
 							$albumId = -2;
+							$this->failCache[] = $album['name'] . $album['year'];
 						}
 					} else {
 						$albumId = $musicCheck['id'];


### PR DESCRIPTION
Temporarily store the music/games/books we've looked up this run that failed so that if we query them again we can immediately return the failure rather than wasting time repeating ourselves.