### PR TITLE
Fix broken pager on search page.

### DIFF
--- a/www/pages/search.php
+++ b/www/pages/search.php
@@ -71,7 +71,6 @@ if ((isset($_REQUEST["id"]) || isset($_REQUEST["subject"])) && !isset($_REQUEST[
 			'pageroffset' => $offset,
 			'pageritemsperpage' => ITEMS_PER_PAGE,
 			'pagerquerysuffix' => "#results",
-			'pager' => $page->smarty->fetch("pager.tpl"),
 			'pagerquerybase' =>
 				WWW_TOP . "/search/" . htmlentities($searchString) . "?t=" .
 				(implode(',', $categoryID)) . "&amp;ob=$orderBy&amp;offset=",
@@ -134,7 +133,6 @@ if (isset($_REQUEST["searchadvr"]) && !isset($_REQUEST["id"]) && !isset($_REQUES
 			'pageroffset' => $offset,
 			'pageritemsperpage' => ITEMS_PER_PAGE,
 			'pagerquerysuffix' => "#results",
-			'pager' => $page->smarty->fetch("pager.tpl"),
 			'pagerquerybase' => WWW_TOP . "/search?searchadvr=$orderByString&search_type=adv&amp;ob=$orderBy&amp;offset="
 		]
 	);
@@ -184,7 +182,8 @@ $page->smarty->assign(
 		'results' => $results, 'sadvanced' => ($searchType != "basic"),
 		'grouplist' => $groups->getGroupsForSelect(),
 		'catlist' => (new Category(['Settings' => $page->settings]))->getForSelect(),
-		'search_description' => $search_description
+		'search_description' => $search_description,
+		'pager' => $page->smarty->fetch("pager.tpl")
 	]
 );
 


### PR DESCRIPTION
Fix an issue where the pager on search page only displayed 1 page.

Caused by my previous refactoring of this file.

The issue was smarty does not have access to the variables if the variables are initiated in an array with the assign method, so move the pager.tpl "fetch" outside the assign method call used for initiating those variables it needs.