### PR TITLE
Amend additional media-types to make sure static files are served correctly

### DIFF
--- a/docs/urlrewriting/lighttpd.txt
+++ b/docs/urlrewriting/lighttpd.txt
@@ -1,5 +1,5 @@
 url.rewrite-once = (
-	"^/.*\.(css|eot|gif|gz|ico|inc|jpe?g|js|ogg|png|svg|ttf|txt|woff|xml)$" => "$0",
+	"^/.*\.(css|eot|gif|gz|ico|inc|jpe?g|js|ogg|oga|ogv|mp4|m4a|mp3|png|svg|ttf|txt|woff|xml)$" => "$0",
 	"^/(admin|install).*$" => "$0",
 	"^/([^/\.]+)/?(?:\?(.*))$" => "index.php?page=$1&$2",
 	"^/([^/\.]+)/?$" => "index.php?page=$1",

--- a/www/.htaccess
+++ b/www/.htaccess
@@ -1,8 +1,8 @@
 RewriteEngine on
 #RewriteBase /
 
-# Do not process images or CSS files further
-RewriteRule \.(css|eot|gif|gz|ico|inc|jpe?g|js|ogg|png|svg|ttf|txt|woff|xml)$ - [L]
+# Do not process image, video or CSS files further
+RewriteRule \.(css|eot|gif|gz|ico|inc|jpe?g|js|ogg|oga|ogv|mp4|m4a|mp3|png|svg|ttf|txt|woff|xml)$ - [L]
 
 # Leave /admin and /install static
 RewriteRule ^(admin|install).*$ - [L]


### PR DESCRIPTION
If you're not using the "Alias" command for covers then certain media types (specifically the ones that weren't previously listed) won't be served as it'll look in the wrong place. This fixes that.