### PR TITLE
Fix on advanced search page.

### DIFF
--- a/www/pages/search.php
+++ b/www/pages/search.php
@@ -133,7 +133,7 @@ if (isset($_REQUEST["searchadvr"]) && !isset($_REQUEST["id"]) && !isset($_REQUES
 			'pageroffset' => $offset,
 			'pageritemsperpage' => ITEMS_PER_PAGE,
 			'pagerquerysuffix' => "#results",
-			'pagerquerybase' => WWW_TOP . "/search?searchadvr=$orderByString&search_type=adv&amp;ob=$orderBy&amp;offset="
+			'pagerquerybase' => WWW_TOP . "/search?$orderByString&search_type=adv&amp;ob=$orderBy&amp;offset="
 		]
 	);
 }


### PR DESCRIPTION
The "searchadvr" GET parameter was set 2 times.