### PR TITLE
Remove superfluous searchname param from href links.

### DIFF
--- a/www/themes/Default/templates/frontend/books.tpl
+++ b/www/themes/Default/templates/frontend/books.tpl
@@ -132,7 +132,7 @@
 																	 value="{$mguid[$m@index]}"/></div>
 										</td>
 										<td>
-											<a href="{$smarty.const.WWW_TOP}/details/{$mguid[$m@index]}/{$mname[$m@index]|escape:"htmlall"}">{$mname[$m@index]|escape:"htmlall"}</a>
+											<a href="{$smarty.const.WWW_TOP}/details/{$mguid[$m@index]}">{$mname[$m@index]|escape:"htmlall"}</a>
 
 											<div>
 												<i class="icon-calendar"></i> Posted {$mpostdate[$m@index]|timeago} | <i
@@ -141,7 +141,7 @@
 																				  href="{$smarty.const.WWW_TOP}/filelist/{$mguid[$m@index]}">{$mtotalparts[$m@index]}
 													files</a> | <i class="icon-comments"></i> <a
 														title="View comments for {$mname[$m@index]|escape:"htmlall"}"
-														href="{$smarty.const.WWW_TOP}/details/{$mguid[$m@index]}/{$mname[$m@index]|escape:"htmlall"}#comments">{$mcomments[$m@index]}
+														href="{$smarty.const.WWW_TOP}/details/{$mguid[$m@index]}#comments">{$mcomments[$m@index]}
 													cmt{if $mcomments[$m@index] != 1}s{/if}</a> | <i
 														class="icon-download"></i> {$mgrabs[$m@index]}
 												grab{if $mgrabs[$m@index] != 1}s{/if} |

--- a/www/themes/Default/templates/frontend/browse.tpl
+++ b/www/themes/Default/templates/frontend/browse.tpl
@@ -106,10 +106,10 @@
 					</td>
 					<td class="item">
 						<label for="chk{$result.guid|substr:0:7}">
-							<a class="title" title="View details" href="{$smarty.const.WWW_TOP}/details/{$result.guid}/{$result.searchname|escape:"htmlall"}">{$result.searchname|escape:"htmlall"|truncate:150:"...":true}</a>
+							<a class="title" title="View details" href="{$smarty.const.WWW_TOP}/details/{$result.guid}">{$result.searchname|escape:"htmlall"|truncate:150:"...":true}</a>
 						</label value="Searchname">
 						<div class="resextra">
-							<a class="browsename" title="View details" href="{$smarty.const.WWW_TOP}/details/{$result.guid}/{$result.searchname|escape:"htmlall"}">{$result.name|escape:"htmlall"|truncate:150:"...":true}</a>
+							<a class="browsename" title="View details" href="{$smarty.const.WWW_TOP}/details/{$result.guid}">{$result.name|escape:"htmlall"|truncate:150:"...":true}</a>
 							<div class="btns" style="float:right">
 								{release_flag($result.searchname, browse)}
 								{if $result.passwordstatus == 1}
@@ -120,7 +120,7 @@
 									<img title="RAR/ZIP is Passworded." src="{$smarty.const.WWW_TOP}/themes_shared/images/icons/lock.gif" alt="RAR/ZIP is Passworded." />
 								{/if}
 								{if $result.videostatus == 1}
-									<a href="{$smarty.const.WWW_TOP}/details/{$result.guid}/{$result.searchname|escape:"htmlall"}" title="This release has a video preview." class="model_prev rndbtn" rel="preview">
+									<a href="{$smarty.const.WWW_TOP}/details/{$result.guid}" title="This release has a video preview." class="model_prev rndbtn" rel="preview">
 										<img src="{$smarty.const.WWW_TOP}/themes_shared/images/multimedia/video.png" />
 									</a>
 								{/if}

--- a/www/themes/Default/templates/frontend/console.tpl
+++ b/www/themes/Default/templates/frontend/console.tpl
@@ -138,7 +138,7 @@
 																	 value="{$mguid[$m@index]}"/></div>
 										</td>
 										<td>
-											<a href="{$smarty.const.WWW_TOP}/details/{$mguid[$m@index]}/{$mname[$m@index]|escape:"htmlall"}">{$mname[$m@index]|escape:"htmlall"}</a>
+											<a href="{$smarty.const.WWW_TOP}/details/{$mguid[$m@index]}">{$mname[$m@index]|escape:"htmlall"}</a>
 
 											<div>
 												<i class="icon-calendar"></i> Posted {$mpostdate[$m@index]|timeago} | <i
@@ -147,7 +147,7 @@
 																				  href="{$smarty.const.WWW_TOP}/filelist/{$mguid[$m@index]}">{$mtotalparts[$m@index]}
 													files</a> | <i class="icon-comments"></i> <a
 														title="View comments for {$mname[$m@index]|escape:"htmlall"}"
-														href="{$smarty.const.WWW_TOP}/details/{$mguid[$m@index]}/{$mname[$m@index]|escape:"htmlall"}#comments">{$mcomments[$m@index]}
+														href="{$smarty.const.WWW_TOP}/details/{$mguid[$m@index]}#comments">{$mcomments[$m@index]}
 													cmt{if $mcomments[$m@index] != 1}s{/if}</a> | <i
 														class="icon-download"></i> {$mgrabs[$m@index]}
 												grab{if $mgrabs[$m@index] != 1}s{/if} |

--- a/www/themes/Default/templates/frontend/games.tpl
+++ b/www/themes/Default/templates/frontend/games.tpl
@@ -165,7 +165,7 @@
 																	 value="{$mguid[$m@index]}"/></div>
 										</td>
 										<td>
-											<a href="{$smarty.const.WWW_TOP}/details/{$mguid[$m@index]}/{$mname[$m@index]|escape:"htmlall"}">{$mname[$m@index]|escape:"htmlall"}</a>
+											<a href="{$smarty.const.WWW_TOP}/details/{$mguid[$m@index]}">{$mname[$m@index]|escape:"htmlall"}</a>
 
 											<div>
 												<i class="icon-calendar"></i> Posted {$mpostdate[$m@index]|timeago} | <i
@@ -174,7 +174,7 @@
 																				  href="{$smarty.const.WWW_TOP}/filelist/{$mguid[$m@index]}">{$mtotalparts[$m@index]}
 													files</a> | <i class="icon-comments"></i> <a
 														title="View comments for {$mname[$m@index]|escape:"htmlall"}"
-														href="{$smarty.const.WWW_TOP}/details/{$mguid[$m@index]}/{$mname[$m@index]|escape:"htmlall"}#comments">{$mcomments[$m@index]}
+														href="{$smarty.const.WWW_TOP}/details/{$mguid[$m@index]}#comments">{$mcomments[$m@index]}
 													cmt{if $mcomments[$m@index] != 1}s{/if}</a> | <i
 														class="icon-download"></i> {$mgrabs[$m@index]}
 												grab{if $mgrabs[$m@index] != 1}s{/if} |

--- a/www/themes/Default/templates/frontend/movies.tpl
+++ b/www/themes/Default/templates/frontend/movies.tpl
@@ -157,7 +157,7 @@
 																	 value="{$mguid[$m@index]}"/></div>
 										</td>
 										<td>
-											<a href="{$smarty.const.WWW_TOP}/details/{$mguid[$m@index]}/{$mname[$m@index]|escape:"htmlall"}">{$mname[$m@index]|escape:"htmlall"}</a>
+											<a href="{$smarty.const.WWW_TOP}/details/{$mguid[$m@index]}">{$mname[$m@index]|escape:"htmlall"}</a>
 
 											<div>
 												<i class="icon-calendar"></i> Posted {$mpostdate[$m@index]|timeago} | <i
@@ -166,7 +166,7 @@
 																				  href="{$smarty.const.WWW_TOP}/filelist/{$mguid[$m@index]}">{$mtotalparts[$m@index]}
 													files</a> | <i class="icon-comments"></i> <a
 														title="View comments for {$mname[$m@index]|escape:"htmlall"}"
-														href="{$smarty.const.WWW_TOP}/details/{$mguid[$m@index]}/{$mname[$m@index]|escape:"htmlall"}#comments">{$mcomments[$m@index]}
+														href="{$smarty.const.WWW_TOP}/details/{$mguid[$m@index]}#comments">{$mcomments[$m@index]}
 													cmt{if $mcomments[$m@index] != 1}s{/if}</a> | <i
 														class="icon-download"></i> {$mgrabs[$m@index]}
 												grab{if $mgrabs[$m@index] != 1}s{/if} |

--- a/www/themes/Default/templates/frontend/music.tpl
+++ b/www/themes/Default/templates/frontend/music.tpl
@@ -158,7 +158,7 @@
 																	 value="{$mguid[$m@index]}"/></div>
 										</td>
 										<td>
-											<a href="{$smarty.const.WWW_TOP}/details/{$mguid[$m@index]}/{$mname[$m@index]|escape:"htmlall"}">{$mname[$m@index]|escape:"htmlall"}</a>
+											<a href="{$smarty.const.WWW_TOP}/details/{$mguid[$m@index]}">{$mname[$m@index]|escape:"htmlall"}</a>
 
 											<div>
 												<i class="icon-calendar"></i> Posted {$mpostdate[$m@index]|timeago} | <i
@@ -167,7 +167,7 @@
 																				  href="{$smarty.const.WWW_TOP}/filelist/{$mguid[$m@index]}">{$mtotalparts[$m@index]}
 													files</a> | <i class="icon-comments"></i> <a
 														title="View comments for {$mname[$m@index]|escape:"htmlall"}"
-														href="{$smarty.const.WWW_TOP}/details/{$mguid[$m@index]}/{$mname[$m@index]|escape:"htmlall"}#comments">{$mcomments[$m@index]}
+														href="{$smarty.const.WWW_TOP}/details#comments">{$mcomments[$m@index]}
 													cmt{if $mcomments[$m@index] != 1}s{/if}</a> | <i
 														class="icon-download"></i> {$mgrabs[$m@index]}
 												grab{if $mgrabs[$m@index] != 1}s{/if} |

--- a/www/themes/Default/templates/frontend/xxx.tpl
+++ b/www/themes/Default/templates/frontend/xxx.tpl
@@ -195,7 +195,7 @@
 										<input type="checkbox" class="nzb_check" value="{$mguid[$m@index]}">
 									</td>
 									<td class="name">
-										<a href="{$smarty.const.WWW_TOP}/details/{$mguid[$m@index]}/{$mname[$m@index]|escape:"htmlall"}">
+										<a href="{$smarty.const.WWW_TOP}/details/{$mguid[$m@index]}">
 											<b>{$mname[$m@index]|escape:"htmlall"}</b>
 										</a>
 										<br>
@@ -212,7 +212,7 @@
 												<i class="icon-comments"></i>
 												<a
 													title="View comments for {$mname[$m@index]|escape:"htmlall"}"
-													href="{$smarty.const.WWW_TOP}/details/{$mguid[$m@index]}/{$mname[$m@index]|escape:"htmlall"}#comments">{$mcomments[$m@index]}
+													href="{$smarty.const.WWW_TOP}/details/{$mguid[$m@index]}#comments">{$mcomments[$m@index]}
 													cmt{if $mcomments[$m@index] != 1}s{/if}
 												</a> |
 												<i class="icon-download"></i> {$mgrabs[$m@index]} grab{if $mgrabs[$m@index] != 1}s{/if}


### PR DESCRIPTION
Prevents searchname from appearing in browser history and proxy logs.

For now only patched the default theme. If this is the correct way to implement this change, I'll do another PR for the other themes.