### PR TITLE
Implementing private profiles and the ability to turn them on or off via the ACP

### DIFF
--- a/nzedb/Users.php
+++ b/nzedb/Users.php
@@ -1426,9 +1426,9 @@ class Users
 	 * @return bool
 	 */
 	public function roleCheck($roleID, $user) {
-		$user = $this->pdo->escapeString($user);
 
 		if (is_string($user) && strlen($user) > 0) {
+			$user = $this->pdo->escapeString($user);
 			$querySuffix = "username = '$user'";
 		} elseif (is_int($user) && $user >= 0) {
 			$querySuffix = "id = $user";

--- a/nzedb/Users.php
+++ b/nzedb/Users.php
@@ -1428,7 +1428,7 @@ class Users
 	public function roleCheck($roleID, $user) {
 		if (is_string($user) && strlen($user) > 0) {
 			$querySuffix = "username = '$user'";
-		} elseif (is_int($user) && $user > 0) {
+		} elseif (is_int($user) && $user >= 0) {
 			$querySuffix = "id = $user";
 		} else {
 			return false;

--- a/nzedb/Users.php
+++ b/nzedb/Users.php
@@ -1426,6 +1426,8 @@ class Users
 	 * @return bool
 	 */
 	public function roleCheck($roleID, $user) {
+		$user = $this->pdo->escapeString($user);
+
 		if (is_string($user) && strlen($user) > 0) {
 			$querySuffix = "username = '$user'";
 		} elseif (is_int($user) && $user >= 0) {

--- a/resources/db/patches/mysql/+1~settings.sql
+++ b/resources/db/patches/mysql/+1~settings.sql
@@ -1,0 +1,1 @@
+INSERT INTO settings (section, subsection, name, value, hint, setting) VALUES ('', '', 'privateprofiles', 1, 'Hide profiles from other users (admin/mod can still access).', 'privateprofiles');

--- a/resources/db/schema/data/10-settings.tsv
+++ b/resources/db/schema/data/10-settings.tsv
@@ -79,6 +79,7 @@ indexer	ppa	innerfileblacklist	/setup\.exe|password\.url/i	You can add a regex h
 		processjpg	0	Whether to attempt to retrieve a JPG file while additional post processing, these are usually on XXX releases.	processjpg
 		processthumbnails	0	Whether to attempt to process a video thumbnail image. You must have ffmpeg for this.	processthumbnails
 		processvideos	0	Whether to attempt to process a video sample, these videos are very short 1-3 seconds, 100KB on average, in ogv format. You must have ffmpeg for this.	processvideos
+		privateprofiles	1	Hide profiles from other users (admin/mod can still access).	privateprofiles
 		registerstatus	0	The status of registrations to the site.	registerstatus
 		releasecompletion	95	The minimum completion % to keep a release. Set to 0 to disable.	releasecompletion
 		releaseretentiondays	0	!!THIS IS NOT HEADER RETENTION!! The number of days releases will be retained for use throughout site. Set to 0 to disable.	releaseretentiondays

--- a/www/pages/details.php
+++ b/www/pages/details.php
@@ -186,6 +186,7 @@ if (isset($_GET['id'])) {
 	$page->smarty->assign('comments', $comments);
 	$page->smarty->assign('similars', $similars);
 	$page->smarty->assign('searchname', $releases->getSimilarName($data['searchname']));
+	$page->smarty->assign('privateprofiles', ($page->settings->getSetting('privateprofiles') == 1) ? true : false );
 
 	$page->meta_title       = 'View NZB';
 	$page->meta_keywords    = 'view,nzb,description,details';

--- a/www/pages/forum.php
+++ b/www/pages/forum.php
@@ -24,6 +24,7 @@ $page->smarty->assign('pageroffset', $offset);
 $page->smarty->assign('pageritemsperpage', ITEMS_PER_PAGE);
 $page->smarty->assign('pagerquerybase', WWW_TOP . "/forum?offset=");
 $page->smarty->assign('pagerquerysuffix', "#results");
+$page->smarty->assign('privateprofiles', ($page->settings->getSetting('privateprofiles') == 1) ? true : false);
 
 $pager = $page->smarty->fetch("pager.tpl");
 $page->smarty->assign('pager', $pager);

--- a/www/pages/forumpost.php
+++ b/www/pages/forumpost.php
@@ -26,6 +26,7 @@ $page->meta_keywords = "view,forum,post,thread";
 $page->meta_description = "View forum post";
 
 $page->smarty->assign('results', $results);
+$page->smarty->assign('privateprofiles', ($page->settings->getSetting('privateprofiles') == 1) ? true : false);
 
 $page->content = $page->smarty->fetch('forumpost.tpl');
 $page->render();

--- a/www/pages/profile.php
+++ b/www/pages/profile.php
@@ -17,18 +17,18 @@ $publicView = false;
 
 if (!$privateProfiles || $privileged) {
 
-	$altID = (isset($_GET['id'])) ? (int) $_GET['id'] : false;
+	$altID = (isset($_GET['id']) && $_GET['id'] >= 0) ? (int) $_GET['id'] : false;
 	$altUsername = (isset($_GET['name']) && strlen($_GET['name']) > 0) ? $_GET['name'] : false;
 
 	// If both 'id' and 'name' are specified, 'id' should take precedence.
-	if (!$altID && $altUsername) {
+	if ($altID === false && $altUsername) {
 		$user = $page->users->getByUsername($altUsername);
 		if ($user) {
 			$altID = $user['id'];
 		}
 	}
 
-	if ($altID) {
+	if ($altID !== false) {
 		$userid = $altID;
 		$publicView = true;
 	}

--- a/www/pages/profile.php
+++ b/www/pages/profile.php
@@ -21,7 +21,7 @@ if (!$privateProfiles || $privileged) {
 	$altUsername = (isset($_GET['name']) && strlen($_GET['name']) > 0) ? $_GET['name'] : false;
 
 	// If both 'id' and 'name' are specified, 'id' should take precedence.
-	if ($altID === false && $altUsername) {
+	if ($altID === false && $altUsername !== false) {
 		$user = $page->users->getByUsername($altUsername);
 		if ($user) {
 			$altID = $user['id'];

--- a/www/pages/profile.php
+++ b/www/pages/profile.php
@@ -11,6 +11,28 @@ $rc  = new ReleaseComments($page->settings);
 $sab = new SABnzbd($page);
 
 $userid = $page->users->currentUserId();
+$privileged = ($page->users->isAdmin($userid) || $page->users->isModerator($userid)) ? true : false;
+$privateProfiles = ($page->settings->getSetting('privateprofiles') == 1) ? true : false;
+$publicView = false;
+
+if (!$privateProfiles || $privileged) {
+
+	$altID = (isset($_GET['id'])) ? (int) $_GET['id'] : false;
+	$altUsername = (isset($_GET['name']) && strlen($_GET['name']) > 0) ? $_GET['name'] : false;
+
+	// If both 'id' and 'name' are specified, 'id' should take precedence.
+	if (!$altID && $altUsername) {
+		$user = $page->users->getByUsername($altUsername);
+		if ($user) {
+			$altID = $user['id'];
+		}
+	}
+
+	if ($altID) {
+		$userid = $altID;
+		$publicView = true;
+	}
+}
 
 $data = $page->users->getById($userid);
 if (!$data) {
@@ -36,6 +58,9 @@ if (!isset($data['style']) || $data['style'] == 'None') {
 
 $page->smarty->assign('userinvitedby', $invitedby);
 $page->smarty->assign('user', $data);
+$page->smarty->assign('privateprofiles', $privateProfiles);
+$page->smarty->assign('publicview', $publicView);
+$page->smarty->assign('privileged', $privileged);
 
 $commentcount = $rc->getCommentCountForUser($userid);
 $offset       = isset($_REQUEST["offset"]) ? $_REQUEST["offset"] : 0;

--- a/www/themes/Default/templates/frontend/forum.tpl
+++ b/www/themes/Default/templates/frontend/forum.tpl
@@ -26,7 +26,11 @@
 				</div>
 			</td>
 			<td>
-				<a title="View profile" href="{$smarty.const.WWW_TOP}/profile/?name={$result.username}">{$result.username}</a>
+				{if !$privateprofiles || $isadmin || $ismod}
+					<a title="View profile" href="{$smarty.const.WWW_TOP}/profile/?name={$result.username}">{$result.username}</a>
+				{else}
+					{$result.username}
+				{/if}
 				<br/>
 				on <span title="{$result.createddate}">{$result.createddate|date_format}</span> <div class="hint">({$result.createddate|timeago})</div>
 			</td>

--- a/www/themes/Default/templates/frontend/forumpost.tpl
+++ b/www/themes/Default/templates/frontend/forumpost.tpl
@@ -17,7 +17,11 @@
 	{foreach from=$results item=result name=result}
 		<tr class="{cycle values=",alt"}">
 			<td width="15%;">
-				<a {if $smarty.foreach.result.last}id="last"{/if} title="View profile" href="{$smarty.const.WWW_TOP}/profile/?name={$result.username}">{$result.username}</a>
+				{if !$privateprofiles || $isadmin || $ismod}
+					<a {if $smarty.foreach.result.last}id="last"{/if} title="View profile" href="{$smarty.const.WWW_TOP}/profile/?name={$result.username}">{$result.username}</a>
+				{else}
+					{$result.username}
+				{/if}
 				<br/>
 				on <span title="{$result.createddate}">{$result.createddate|date_format}</span> <div class="hint">({$result.createddate|timeago})</div>
 				{if $userdata.role==2}

--- a/www/themes/Default/templates/frontend/profile.tpl
+++ b/www/themes/Default/templates/frontend/profile.tpl
@@ -3,16 +3,16 @@
 
 <table class="data">
 	<tr><th>Username:</th><td>{$user.username|escape:"htmlall"}</td></tr>
-	{if $user.id==$userdata.id || $userdata.role==2}<tr><th title="Not public">Email:</th><td>{$user.email}</td></tr>{/if}
+	{if $isadmin || !$publicview}<tr><th title="Not public">Email:</th><td>{$user.email}</td></tr>{/if}
 	<tr><th>Registered:</th><td title="{$user.createddate}">{$user.createddate|date_format}  ({$user.createddate|timeago} ago)</td></tr>
 	<tr><th>Last Login:</th><td title="{$user.lastlogin}">{$user.lastlogin|date_format}  ({$user.lastlogin|timeago} ago)</td></tr>
 	<tr><th>Role:</th><td>{$user.rolename}</td></tr>
 	<tr><th>Theme:</th><td>{$user.style}</td></tr>
-	{if $user.id==$userdata.id || $userdata.role==2}<tr><th title="Not public">Site Api/Rss Key:</th><td><a href="{$smarty.const.WWW_TOP}/rss?t=0&amp;dl=1&amp;i={$userdata.id}&amp;r={$userdata.rsstoken}">{$user.rsstoken}</a></td></tr>{/if}
+	{if $isadmin || !$publicview}<tr><th title="Not public">Site Api/Rss Key:</th><td><a href="{$smarty.const.WWW_TOP}/rss?t=0&amp;dl=1&amp;i={$user.id}&amp;r={$user.rsstoken}">{$user.rsstoken}</a></td></tr>{/if}
 	<tr><th>Grabs:</th><td>{$user.grabs}</td></tr>
 	<tr><th>API Requests Today:</th><td>{$apirequests}</td></tr>
 
-	{if ($user.id==$userdata.id || $userdata.role==2) && $site->registerstatus==1}
+	{if (!$publicview || $isadmin) && $site->registerstatus==1}
 	<tr>
 		<th title="Not public">Invites:</th>
 		<td>{$user.invites}
@@ -33,7 +33,13 @@
 	{/if}
 
 	{if $userinvitedby && $userinvitedby.username != ""}
-	<tr><th>Invited By:</th><td><a title="View {$userinvitedby.username}'s profile" href="{$smarty.const.WWW_TOP}/profile?name={$userinvitedby.username}">{$userinvitedby.username}</a></td>
+	<tr><th>Invited By:</th><td>
+			{if $privileged || !$privateprofiles}
+				<a title="View {$userinvitedby.username}'s profile" href="{$smarty.const.WWW_TOP}/profile?name={$userinvitedby.username}">{$userinvitedby.username}</a>
+			{else}
+				{$userinvitedby.username}
+			{/if}
+		</td>
 	{/if}
 
 	<tr><th>UI Preferences:</th>
@@ -46,8 +52,8 @@
 			{if $user.bookview == "1"}View book covers{else}View standard book category{/if}
 		</td>
 	</tr>
-	{if $user.id==$userdata.id || $userdata.role==2}<tr><th title="Not public">Excluded Categories:</th><td>{$exccats|replace:",":"<br/>"}</td></tr>{/if}
-	{if $page->settings->getSetting('sabintegrationtype') == 2 && $user.id==$userdata.id}
+	{if !$publicview || $isadmin}<tr><th title="Not public">Excluded Categories:</th><td>{$exccats|replace:",":"<br/>"}</td></tr>{/if}
+	{if $page->settings->getSetting('sabintegrationtype') == 2 && (!$publicview || $isadmin)}
 		<tr><th>SABnzbd Integration:</th>
 		<td>
 			Url: {if $saburl == ''}N/A{else}{$saburl}{/if}<br/>
@@ -57,19 +63,21 @@
 			Storage: {if $sabsetting == ''}N/A{else}{$sabsetting}{/if}
 		</td>
 	{/if}
+
+	{if !$publicview || $isadmin}
 	<tr><th>CouchPotato Integration:</th>
 	<td>
 		Url: {if $user.cp_url == ''}N/A{else}{$user.cp_url}{/if}<br/>
 		Key: {if $user.cp_api == ''}N/A{else}{$user.cp_api}{/if}<br/>
 	</td>
-
-	{if $user.id==$userdata.id}
-			<tr><th>My TV Shows:</th><td><a href="{$smarty.const.WWW_TOP}/myshows">Manage my shows</a></td></tr>
-			<tr><th>My Movies:</th><td><a href="{$smarty.const.WWW_TOP}/mymovies">Manage my movies</a></td></tr>
 	{/if}
 
+	{if !$publicview}
+	<tr><th>My TV Shows:</th><td><a href="{$smarty.const.WWW_TOP}/myshows">Manage my shows</a></td></tr>
+	<tr><th>My Movies:</th><td><a href="{$smarty.const.WWW_TOP}/mymovies">Manage my movies</a></td></tr>
 
-	{if $user.id==$userdata.id}<tr><th></th><td><a href="{$smarty.const.WWW_TOP}/profileedit">Edit</a></td></tr>{/if}
+	<tr><th></th><td><a href="{$smarty.const.WWW_TOP}/profileedit">Edit</a></td></tr>
+	{/if}
 </table>
 
 {if $commentslist|@count > 0}

--- a/www/themes/Default/templates/frontend/viewnzb.tpl
+++ b/www/themes/Default/templates/frontend/viewnzb.tpl
@@ -459,7 +459,14 @@
 			</tr>
 		{foreach from=$comments item=comment}
 			<tr>
-				<td class="less" title="{$comment.createddate}"><a title="View {$comment.username}'s profile" href="{$smarty.const.WWW_TOP}/profile?name={$comment.username}">{$comment.username}</a><br/>{$comment.createddate|date_format}</td>
+
+				<td class="less" title="{$comment.createddate}">
+					{if !$privateprofiles || $isadmin || $ismod}
+						<a title="View {$comment.username}'s profile" href="{$smarty.const.WWW_TOP}/profile?name={$comment.username}">{$comment.username}</a>
+					{else}
+						{$comment.username}
+					{/if}
+					<br/>{$comment.createddate|date_format}</td>
 				{if $comment.shared == 2}
 					<td style="color:#6B2447">{$comment.text|escape:"htmlall"|nl2br}</td>
 				{else}

--- a/www/themes/alpha/templates/frontend/forum.tpl
+++ b/www/themes/alpha/templates/frontend/forum.tpl
@@ -27,7 +27,11 @@
 					</div>
 				</td>
 				<td style="width:auto;text-align:center;white-space:nowrap;">
-					<a title="View profile" href="{$smarty.const.WWW_TOP}/profile/?name={$result.username}">{$result.username}</a><br>
+					{if !$privateprofiles || $isadmin || $ismod}
+						<a title="View profile" href="{$smarty.const.WWW_TOP}/profile/?name={$result.username}">{$result.username}</a><br>
+					{else}
+						{$result.username}
+					{/if}
 					<span title="{$result.createddate}">{$result.createddate|date_format}</span> ({$result.createddate|timeago})
 				</td>
 				<td style="width:auto;text-align:center;">

--- a/www/themes/alpha/templates/frontend/forumpost.tpl
+++ b/www/themes/alpha/templates/frontend/forumpost.tpl
@@ -19,7 +19,12 @@
 		{foreach from=$results item=result name=result}
 			<tr>
 				<td>
-					<a {if $smarty.foreach.result.last}id="last"{/if} title="View profile" href="{$smarty.const.WWW_TOP}/profile/?name={$result.username}">{$result.username}</a> on<br>
+					{if !$privateprofiles || $isadmin || $ismod}
+						<a {if $smarty.foreach.result.last}id="last"{/if} title="View profile" href="{$smarty.const.WWW_TOP}/profile/?name={$result.username}">{$result.username}</a>
+					{else}
+						{$result.username}
+					{/if}
+					 on<br>
 					<span title="{$result.createddate}">{$result.createddate|date_format}</span> ({$result.createddate|timeago})
 					{if $isadmin || $ismod}
 						<div>

--- a/www/themes/alpha/templates/frontend/profile.tpl
+++ b/www/themes/alpha/templates/frontend/profile.tpl
@@ -7,12 +7,12 @@
 		<th>Username:</th>
 		<td>{$user.username|escape:"htmlall"}</td>
 	</tr>
-
-	{if $user.id==$userdata.id || $userdata.role==2}
+	{if $isadmin || !$publicview}
 		<tr>
 		<th title="Not public">Email:</th>
 		<td>{$user.email}</td>
-		</tr>{/if}
+		</tr>
+	{/if}
 	<tr>
 		<th>Registered:</th>
 		<td title="{$user.createddate}">{$user.createddate|date_format}  ({$user.createddate|timeago} ago)</td>
@@ -29,17 +29,19 @@
 		<th>Theme:</th>
 		<td>{$user.style}</td>
 	</tr>
-	{if $user.id==$userdata.id || $userdata.role==2}<tr>
+	{if $isadmin || !$publicview}
+	<tr>
 		<th title="Not public">Site Api/Rss Key:</th>
-		<td><a href="{$smarty.const.WWW_TOP}/rss?t=0&amp;dl=1&amp;i={$userdata.id}&amp;r={$userdata.rsstoken}">{$user.rsstoken}</a></td>
-		</tr>{/if}
+		<td><a href="{$smarty.const.WWW_TOP}/rss?t=0&amp;dl=1&amp;i={$user.id}&amp;r={$user.rsstoken}">{$user.rsstoken}</a></td>
+	</tr>
+	{/if}
 	<tr>
 		<th>Grabs:</th>
 		<td>{$user.grabs}</td>
 	</tr>
 	<tr><th>API Requests Today:</th><td>{$apirequests}</td></tr>
 
-	{if ($user.id==$userdata.id || $userdata.role==2) && $site->registerstatus==1}
+	{if (!$publicview || $isadmin) && $site->registerstatus==1}
 		<tr>
 		<th title="Not public">Invites:</th>
 		<td>{$user.invites}
@@ -61,7 +63,14 @@
 	{if $userinvitedby && $userinvitedby.username != ""}
 		<tr>
 		<th>Invited By:</th>
-		<td><a title="View {$userinvitedby.username}'s profile" href="{$smarty.const.WWW_TOP}/profile?name={$userinvitedby.username}">{$userinvitedby.username}</a></td>
+		<td>
+			{if $privileged || !$privateprofiles}
+				<a title="View {$userinvitedby.username}'s profile" href="{$smarty.const.WWW_TOP}/profile?name={$userinvitedby.username}">{$userinvitedby.username}</a>
+			{else}
+				{$userinvitedby.username}
+			{/if}
+
+		</td>
 		</tr>{/if}
 
 	<tr>
@@ -75,10 +84,12 @@
 			{if $user.bookview == "1"}View book covers{else}View standard book category{/if}
 		</td>
 	</tr>
-	{if $user.id==$userdata.id || $userdata.role==2}<tr><th title="Not public">Excluded Categories:</th>
+	{if !$publicview || $isadmin}
+	<tr><th title="Not public">Excluded Categories:</th>
 		<td>{$exccats|replace:",":"<br/>"}</td>
-		</tr>{/if}
-	{if $page->settings->getSetting('sabintegrationtype') == 2 && $user.id==$userdata.id}
+	</tr>
+	{/if}
+	{if $page->settings->getSetting('sabintegrationtype') == 2 && (!$publicview || $isadmin)}
 		<tr>
 		<th>SABnzbd Integration:</th>
 		<td>
@@ -90,27 +101,26 @@
 		</td>
 		</tr>
 	{/if}
+	{if !$publicview || $isadmin}
 	<tr><th>CouchPotato Integration:</th>
 		<td>
 			Url: {if $user.cp_url == ''}N/A{else}{$user.cp_url}{/if}<br/>
 			Key: {if $user.cp_api == ''}N/A{else}{$user.cp_api}{/if}<br/>
 		</td>
 	</tr>
-	{if $user.id==$userdata.id}
 		<tr>
 			<th>My TV Shows:</th>
 			<td><a href="{$smarty.const.WWW_TOP}/myshows">Manage my shows</a></td>
 		</tr>
 		<tr>
-		<th>My Movies:</th>
-		<td><a href="{$smarty.const.WWW_TOP}/mymovies">Manage my movies</a></td>
-		</tr>{/if}
-
-
-	{if $user.id==$userdata.id}<tr>
+			<th>My Movies:</th>
+			<td><a href="{$smarty.const.WWW_TOP}/mymovies">Manage my movies</a></td>
+		</tr>
+	<tr>
 		<th></th>
 		<td><a href="{$smarty.const.WWW_TOP}/profileedit">Edit</a></td>
-		</tr>{/if}
+	</tr>
+	{/if}
 </table>
 
 {if $commentslist|@count > 0}

--- a/www/themes/alpha/templates/frontend/viewnzb.tpl
+++ b/www/themes/alpha/templates/frontend/viewnzb.tpl
@@ -610,7 +610,11 @@
 				{foreach from=$comments item=comment}
 					<tr>
 						<td class="less" title="{$comment.createddate}">
-							<a title="View {$comment.username}'s profile" href="{$smarty.const.WWW_TOP}/profile?name={$comment.username}">{$comment.username}</a>
+							{if !$privateprofiles || $isadmin || $ismod}
+								<a title="View {$comment.username}'s profile" href="{$smarty.const.WWW_TOP}/profile?name={$comment.username}">{$comment.username}</a>
+							{else}
+								{$comment.username}
+							{/if}
 							<br/>{$comment.createddate|date_format} ({$comment.createddate|timeago} ago)
 						</td>
 						{if $comment.shared == 2}

--- a/www/themes/light/templates/frontend/profile.tpl
+++ b/www/themes/light/templates/frontend/profile.tpl
@@ -3,16 +3,16 @@
 
 <table class="data">
 	<tr><th>Username:</th><td>{$user.username|escape:"htmlall"}</td></tr>
-	{if $user.id==$userdata.id || $userdata.role==2}<tr><th title="Not public">Email:</th><td>{$user.email}</td></tr>{/if}
+	{if $isadmin || !$publicview}<tr><th title="Not public">Email:</th><td>{$user.email}</td></tr>{/if}
 	<tr><th>Registered:</th><td title="{$user.createddate}">{$user.createddate|date_format}  ({$user.createddate|timeago} ago)</td></tr>
 	<tr><th>Last Login:</th><td title="{$user.lastlogin}">{$user.lastlogin|date_format}  ({$user.lastlogin|timeago} ago)</td></tr>
 	<tr><th>Role:</th><td>{$user.rolename}</td></tr>
 	<tr><th>Theme:</th><td>{$user.style}</td></tr>
-	{if $user.id==$userdata.id || $userdata.role==2}<tr><th title="Not public">Site Api/Rss Key:</th><td><a href="{$smarty.const.WWW_TOP}/rss?t=0&amp;dl=1&amp;i={$userdata.id}&amp;r={$userdata.rsstoken}">{$user.rsstoken}</a></td></tr>{/if}
+	{if $isadmin || !$publicview}<tr><th title="Not public">Site Api/Rss Key:</th><td><a href="{$smarty.const.WWW_TOP}/rss?t=0&amp;dl=1&amp;i={$user.id}&amp;r={$user.rsstoken}">{$user.rsstoken}</a></td></tr>{/if}
 	<tr><th>Grabs:</th><td>{$user.grabs}</td></tr>
 	<tr><th>API Requests Today:</th><td>{$apirequests}</td></tr>
 
-	{if ($user.id==$userdata.id || $userdata.role==2) && $site->registerstatus==1}
+	{if (!$publicview || $isadmin) && $site->registerstatus==1}
 	<tr>
 		<th title="Not public">Invites:</th>
 		<td>{$user.invites}
@@ -33,7 +33,13 @@
 	{/if}
 
 	{if $userinvitedby && $userinvitedby.username != ""}
-	<tr><th>Invited By:</th><td><a title="View {$userinvitedby.username}'s profile" href="{$smarty.const.WWW_TOP}/profile?name={$userinvitedby.username}">{$userinvitedby.username}</a></td>
+	<tr><th>Invited By:</th><td>
+			{if $privileged || !$privateprofiles}
+				<a title="View {$userinvitedby.username}'s profile" href="{$smarty.const.WWW_TOP}/profile?name={$userinvitedby.username}">{$userinvitedby.username}</a>
+			{else}
+				{$userinvitedby.username}
+			{/if}
+		</td>
 	{/if}
 
 	<tr><th>UI Preferences:</th>
@@ -44,8 +50,8 @@
 			{if $user.bookview == "1"}View book covers{else}View standard book category{/if}
 		</td>
 	</tr>
-	{if $user.id==$userdata.id || $userdata.role==2}<tr><th title="Not public">Excluded Categories:</th><td>{$exccats|replace:",":"<br/>"}</td></tr>{/if}
-	{if $page->settings->getSetting('sabintegrationtype') == 2 && $user.id==$userdata.id}
+	{if !$publicview || $isadmin}<tr><th title="Not public">Excluded Categories:</th><td>{$exccats|replace:",":"<br/>"}</td></tr>{/if}
+	{if $page->settings->getSetting('sabintegrationtype') == 2 && (!$publicview || $isadmin)}
 		<tr><th>SABnzbd Integration:</th>
 		<td>
 			Url: {if $saburl == ''}N/A{else}{$saburl}{/if}<br/>
@@ -55,19 +61,18 @@
 			Storage: {if $sabsetting == ''}N/A{else}{$sabsetting}{/if}
 		</td>
 	{/if}
+	{if !$publicview || $isadmin}
 	<tr><th>CouchPotato Integration:</th>
 	<td>
 		Url: {if $user.cp_url == ''}N/A{else}{$user.cp_url}{/if}<br/>
 		Key: {if $user.cp_api == ''}N/A{else}{$user.cp_api}{/if}<br/>
 	</td>
-
-	{if $user.id==$userdata.id}
+	{/if}
+	{if !$publicview}
 			<tr><th>My TV Shows:</th><td><a href="{$smarty.const.WWW_TOP}/myshows">Manage my shows</a></td></tr>
 			<tr><th>My Movies:</th><td><a href="{$smarty.const.WWW_TOP}/mymovies">Manage my movies</a></td></tr>
-	{/if}
 
-
-	{if $user.id==$userdata.id}<tr><th></th><td><a href="{$smarty.const.WWW_TOP}/profileedit">Edit</a></td></tr>{/if}
+	<tr><th></th><td><a href="{$smarty.const.WWW_TOP}/profileedit">Edit</a></td></tr>{/if}
 </table>
 
 {if $commentslist|@count > 0}

--- a/www/themes_shared/templates/admin/site-edit.tpl
+++ b/www/themes_shared/templates/admin/site-edit.tpl
@@ -1234,6 +1234,13 @@
 					<div class="hint">Whether to store the users ip address when they signup or login.</div>
 				</td>
 			</tr>
+			<tr>
+				<td style="width:180px;"><label for="privateprofiles">Private Profiles:</label></td>
+				<td>
+					{html_radios id="privateprofiles" name='privateprofiles' values=$yesno_ids output=$yesno_names selected=$site->privateprofiles separator='<br />'}
+					<div class="hint">Should we <strong>disallow</strong> users from accessing profiles other than their own? (regardless of this setting admin/mod can access).</div>
+				</td>
+			</tr>
 		</table>
 	</fieldset>
 	<input type="submit" value="Save Site Settings"/>


### PR DESCRIPTION
1. Updated the relevant templates to no longer show links to the profile page for other users unless:
    * The site admin has disabled private profiles in the admin panel, or
    * The viewing user is an admin or moderator.
2. Modified the profile page to no longer accept the additional query parameters unless:
    * The site admin has disabled private profiles in the admin panel, or
    * The viewing user is an admin or moderator.
3. Modified the profile page to no longer display CouchPotato connection details unless:
    * The viewing user is the owner of the profile, or
    * The viewing user is an admin (not moderators)
4. Modified the profile page to display Sab/NZBGet connection details to admins (previously only profile owner could see these but since admin can query on database, might as well show them).
5. Fixed curious bug on profile page that used ```userdata``` instead of ```user``` when displaying RSS token. 
6. Implemented new ```Users``` method for checking roles. This was to keep it dry.
7. Implemented wrapper methods for ```roleCheck()``` specifically for checking admin or mod roles. 
8. Modified existing ```isDisabled()``` method to use ```roleCheck()```.

Todo:

1. Implement caching inside ```roleCheck()``` since this data is unlikely to change.
2. Find a less delicate way to handle ```roleCheck()```'s user identifier logic. Basing on type is bound to cause issues with sloppy devs ;)

Fixes #1708 