### PR TITLE
Ordering comments by created date. Showing newest on top.

### DIFF
--- a/nzedb/ReleaseComments.php
+++ b/nzedb/ReleaseComments.php
@@ -26,7 +26,7 @@ class ReleaseComments
 
 	public function getComments($id)
 	{
-		return $this->pdo->query(sprintf("SELECT release_comments.* FROM release_comments WHERE releaseid = %d", $id));
+		return $this->pdo->query(sprintf("SELECT release_comments.* FROM release_comments WHERE releaseid = %d ORDER BY createddate DESC", $id));
 	}
 
 	public function getCommentCount()


### PR DESCRIPTION
For some reason comments weren't ordered at all. On releases with many comments, especially if sharing is on, you see the comment created date out of order.

This fix orders them descending which puts the newest comment on top, this is default behavior for this type of comment.  