### PR TITLE
Add support for APCu or APC for caching.

### DIFF
--- a/nzedb/libraries/Cache.php
+++ b/nzedb/libraries/Cache.php
@@ -37,12 +37,6 @@ class Cache
 	private $socketFile;
 
 	/**
-	 * Serializer type.
-	 * @var bool|int
-	 */
-	private $serializerType;
-
-	/**
 	 * Does the user have igBinary support and wants to use it?
 	 * @var bool
 	 */
@@ -80,7 +74,7 @@ class Cache
 	 */
 	private function serializeData(&$data)
 	{
-		switch ($this->serializerType) {
+		switch (nZEDb_CACHE_SERIALIZER) {
 			case self::SERIALIZER_IGBINARY:
 				if ($this->IgBinarySupport) {
 					$data = igbinary_serialize($data);
@@ -131,7 +125,7 @@ class Cache
 	 */
 	private function unserializeData(&$data)
 	{
-		switch ($this->serializerType) {
+		switch (nZEDb_CACHE_SERIALIZER) {
 			case self::SERIALIZER_IGBINARY:
 				if ($this->IgBinarySupport) {
 					$data = igbinary_unserialize($data);
@@ -392,7 +386,6 @@ class Cache
 	 */
 	private function verifySerializer()
 	{
-		$this->serializerType = nZEDb_CACHE_SERIALIZER;
 		switch (nZEDb_CACHE_SERIALIZER) {
 			case self::SERIALIZER_IGBINARY:
 				if (!extension_loaded('igbinary')) {

--- a/nzedb/libraries/Cache.php
+++ b/nzedb/libraries/Cache.php
@@ -392,6 +392,7 @@ class Cache
 	 */
 	private function verifySerializer()
 	{
+		$this->serializerType = nZEDb_CACHE_SERIALIZER;
 		switch (nZEDb_CACHE_SERIALIZER) {
 			case self::SERIALIZER_IGBINARY:
 				if (!extension_loaded('igbinary')) {

--- a/nzedb/libraries/Cache.php
+++ b/nzedb/libraries/Cache.php
@@ -70,7 +70,7 @@ class Cache
 	/**
 	 * Serialize data, or not based on admin setting.
 	 *
-	 * @param string $data
+	 * @param string|array $data
 	 */
 	private function serializeData(&$data)
 	{
@@ -156,7 +156,7 @@ class Cache
 			switch (nZEDb_CACHE_TYPE) {
 				case self::TYPE_REDIS:
 				case self::TYPE_MEMCACHED:
-					return (bool) $this->server->delete($key);
+					return (bool)$this->server->delete($key);
 				case self::TYPE_APC:
 					return apc_delete($key);
 			}
@@ -354,8 +354,9 @@ class Cache
 		switch (nZEDb_CACHE_TYPE) {
 			case self::TYPE_REDIS:
 				try {
-					return (bool) $this->server->ping();
+					return (bool)$this->server->ping();
 				} catch (\RedisException $error) {
+					// nothing to see here, move along
 				}
 				break;
 			case self::TYPE_MEMCACHED:
@@ -405,7 +406,6 @@ class Cache
 					default:
 						return null;
 				}
-				break;
 
 			case self::SERIALIZER_NONE:
 				// Only redis supports this.

--- a/nzedb/libraries/Cache.php
+++ b/nzedb/libraries/Cache.php
@@ -17,6 +17,7 @@ class Cache
 	const TYPE_DISABLED  = 0;
 	const TYPE_MEMCACHED = 1;
 	const TYPE_REDIS     = 2;
+	const TYPE_APC       = 3;
 
 	/**
 	 * @var \Memcached|\Redis
@@ -42,12 +43,6 @@ class Cache
 	private $serializerType;
 
 	/**
-	 * Are we using redis or memcached?
-	 * @var bool
-	 */
-	private $isRedis = true;
-
-	/**
 	 * Does the user have igBinary support and wants to use it?
 	 * @var bool
 	 */
@@ -65,14 +60,41 @@ class Cache
 	 */
 	public function set($key, $data, $expiration)
 	{
-		if ($this->connected === true && $this->ping() === true) {
-			return $this->server->set(
-				$key,
-				($this->isRedis ? ($this->IgBinarySupport ? igbinary_serialize($data) : serialize($data)) : $data),
-				$expiration
-			);
+		if ($this->ping()) {
+			$this->serializeData($data);
+			switch (nZEDb_CACHE_TYPE) {
+				case self::TYPE_REDIS:
+				case self::TYPE_MEMCACHED:
+					return $this->server->set($key, $data, $expiration);
+				case self::TYPE_APC:
+					return apc_add($key, $data, $expiration);
+			}
 		}
 		return false;
+	}
+
+	/**
+	 * Serialize data, or not based on admin setting.
+	 *
+	 * @param string $data
+	 */
+	private function serializeData(&$data)
+	{
+		switch ($this->serializerType) {
+			case self::SERIALIZER_IGBINARY:
+				if ($this->IgBinarySupport) {
+					$data = igbinary_serialize($data);
+				} else {
+					$data = serialize($data);
+				}
+				break;
+			case self::SERIALIZER_PHP:
+				$data = serialize($data);
+				break;
+			case self::SERIALIZER_NONE:
+			default:
+				break;
+		}
 	}
 
 	/**
@@ -85,11 +107,45 @@ class Cache
 	 */
 	public function get($key)
 	{
-		if ($this->connected === true && $this->ping() === true) {
-			$data = $this->server->get($key);
-			return ($this->isRedis ? ($this->IgBinarySupport ? igbinary_unserialize($data) : unserialize($data)) : $data);
+		if ($this->ping()) {
+			$data = '';
+			switch (nZEDb_CACHE_TYPE) {
+				case self::TYPE_REDIS:
+				case self::TYPE_MEMCACHED:
+					$data = $this->server->get($key);
+					break;
+				case self::TYPE_APC:
+					$data = apc_fetch($key);
+					break;
+			}
+			$this->unserializeData($data);
+			return $data;
 		}
 		return false;
+	}
+
+	/**
+	 * Un-serialize data, or not based on admin setting.
+	 *
+	 * @param string $data
+	 */
+	private function unserializeData(&$data)
+	{
+		switch ($this->serializerType) {
+			case self::SERIALIZER_IGBINARY:
+				if ($this->IgBinarySupport) {
+					$data = igbinary_unserialize($data);
+				} else {
+					$data = serialize($data);
+				}
+				break;
+			case self::SERIALIZER_PHP:
+				$data = unserialize($data);
+				break;
+			case self::SERIALIZER_NONE:
+			default:
+				break;
+		}
 	}
 
 	/**
@@ -102,8 +158,14 @@ class Cache
 	 */
 	public function delete($key)
 	{
-		if ($this->connected === true && $this->ping() === true) {
-			return (bool)$this->server->delete($key);
+		if ($this->ping()) {
+			switch (nZEDb_CACHE_TYPE) {
+				case self::TYPE_REDIS:
+				case self::TYPE_MEMCACHED:
+					return (bool) $this->server->delete($key);
+				case self::TYPE_APC:
+					return apc_delete($key);
+			}
 		}
 		return false;
 	}
@@ -113,11 +175,18 @@ class Cache
 	 */
 	public function flush()
 	{
-		if ($this->connected === true && $this->ping() === true) {
-			if ($this->isRedis === true) {
-				$this->server->flushAll();
-			} else {
-				$this->server->flush();
+		if ($this->ping()) {
+			switch (nZEDb_CACHE_TYPE) {
+				case self::TYPE_REDIS:
+					$this->server->flushAll();
+					break;
+				case self::TYPE_MEMCACHED:
+					$this->server->flush();
+					break;
+				case self::TYPE_APC:
+					apc_clear_cache("user");
+					apc_clear_cache();
+					break;
 			}
 		}
 	}
@@ -138,16 +207,19 @@ class Cache
 	/**
 	 * Get cache server statistics.
 	 *
-	 * @return array|string
+	 * @return array
 	 * @access public
 	 */
 	public function serverStatistics()
 	{
-		if ($this->connected === true && $this->ping() === true) {
-			if ($this->isRedis === true) {
-				return $this->server->info();
-			} else {
-				return $this->server->getStats();
+		if ($this->ping()) {
+			switch (nZEDb_CACHE_TYPE) {
+				case self::TYPE_REDIS:
+					return $this->server->info();
+				case self::TYPE_MEMCACHED:
+					return $this->server->getStats();
+				case self::TYPE_APC:
+					return apc_cache_info();
 			}
 		}
 		return array();
@@ -175,9 +247,9 @@ class Cache
 			$this->socketFile = true;
 		}
 
-		$this->serializerType = false;
+		$serializer = false;
 		if (defined('nZEDb_CACHE_SERIALIZER')) {
-			$this->serializerType = true;
+			$serializer = true;
 		}
 
 		switch (nZEDb_CACHE_TYPE) {
@@ -187,11 +259,9 @@ class Cache
 					throw new CacheException('The redis extension is not loaded!');
 				}
 				$this->server = new \Redis();
-				$this->isRedis = true;
 				$this->connect();
-				if ($this->serializerType !== false) {
-					$this->serializerType = $this->verifySerializer();
-					$this->server->setOption(\Redis::OPT_SERIALIZER, $this->serializerType);
+				if ($serializer) {
+					$this->server->setOption(\Redis::OPT_SERIALIZER, $this->verifySerializer());
 				}
 				break;
 
@@ -200,18 +270,23 @@ class Cache
 					throw new CacheException('The memcached extension is not loaded!');
 				}
 				$this->server = new \Memcached();
-				$this->isRedis = false;
-				if ($this->serializerType !== false) {
-					$this->serializerType = $this->verifySerializer();
-					$this->server->setOption(\Memcached::OPT_SERIALIZER, $this->serializerType);
+				if ($serializer) {
+					$this->server->setOption(\Memcached::OPT_SERIALIZER, $this->verifySerializer());
 				}
 				$this->server->setOption(\Memcached::OPT_COMPRESSION, (defined('nZEDb_CACHE_COMPRESSION') ? nZEDb_CACHE_COMPRESSION : false));
 				$this->connect();
 				break;
 
+			case self::TYPE_APC:
+				if (!function_exists('apc_set')) {
+					throw new CacheException('The APC extension is not loaded!');
+				}
+				$this->connect();
+				break;
+
 			case self::TYPE_DISABLED:
 			default:
-				return;
+				break;
 		}
 	}
 
@@ -239,54 +314,73 @@ class Cache
 	private function connect()
 	{
 		$this->connected = false;
-		if ($this->isRedis === true) {
-			if ($this->socketFile === false) {
-				$servers = unserialize(nZEDb_CACHE_HOSTS);
-				foreach ($servers as $server) {
-					if ($this->server->connect($server['host'], $server['port'], (float)nZEDb_CACHE_TIMEOUT) === false) {
+		switch (nZEDb_CACHE_TYPE) {
+			case self::TYPE_REDIS:
+				if ($this->socketFile === false) {
+					$servers = unserialize(nZEDb_CACHE_HOSTS);
+					foreach ($servers as $server) {
+						if ($this->server->connect($server['host'], $server['port'], (float)nZEDb_CACHE_TIMEOUT) === false) {
+							throw new CacheException('Error connecting to the Redis server!');
+						} else {
+							$this->connected = true;
+						}
+					}
+				} else {
+					if ($this->server->connect(nZEDb_CACHE_SOCKET_FILE) === false) {
 						throw new CacheException('Error connecting to the Redis server!');
 					} else {
 						$this->connected = true;
 					}
 				}
-			} else {
-				if ($this->server->connect(nZEDb_CACHE_SOCKET_FILE) === false) {
-					throw new CacheException('Error connecting to the Redis server!');
-				} else {
-					$this->connected = true;
-				}
-			}
-		} else {
-			if ($this->socketFile === false) {
-				if ($this->server->addServers(unserialize(nZEDb_CACHE_HOSTS)) === false) {
+				break;
+			case self::TYPE_MEMCACHED:
+				$params = ($this->socketFile === false ? unserialize(nZEDb_CACHE_HOSTS) : [[nZEDb_CACHE_SOCKET_FILE, 'port' => 0]]);
+				if ($this->server->addServers($params) === false) {
 					throw new CacheException('Error connecting to the Memcached server!');
 				} else {
 					$this->connected = true;
 				}
-			} else {
-				if ($this->server->addServers(array(array(nZEDb_CACHE_SOCKET_FILE, 'port' => 0))) === false) {
-					throw new CacheException('Error connecting to the Memcached server!');
-				} else {
-					$this->connected = true;
-				}
-			}
+				break;
+			case self::TYPE_APC:
+				$this->connected = true;
+				break;
 		}
 	}
 
 	/**
-	 * Redis supports ping'ing the server, so use it.
+	 * Check if we are still connected to the cache server, reconnect if not.
+	 *
+	 * @return bool
 	 */
 	private function ping()
 	{
-		if ($this->isRedis === true) {
-			try {
-				return (bool)$this->server->ping();
-			} catch (\RedisException $error) {
-				$this->connect();
-				return $this->connected;
-			}
+		if (!$this->connected) {
+			return false;
 		}
-		return true;
+		switch (nZEDb_CACHE_TYPE) {
+			case self::TYPE_REDIS:
+				try {
+					return (bool) $this->server->ping();
+				} catch (\RedisException $error) {
+				}
+				break;
+			case self::TYPE_MEMCACHED:
+				$versions = $this->server->getVersion();
+				if ($versions) {
+					foreach ($versions as $version) {
+						if ($version != "255.255.255") {
+							return true;
+						}
+					}
+				}
+				break;
+			case self::TYPE_APC:
+				return true;
+			default:
+				return false;
+		}
+		$this->connect();
+		return $this->connected;
 	}
 
 	/**
@@ -300,32 +394,41 @@ class Cache
 	{
 		switch (nZEDb_CACHE_SERIALIZER) {
 			case self::SERIALIZER_IGBINARY:
-				if (extension_loaded('igbinary')) {
-					$this->IgBinarySupport = true;
-					if ($this->isRedis === true) {
-						return \Redis::SERIALIZER_IGBINARY;
-					} else {
-						if (\Memcached::HAVE_IGBINARY > 0) {
-							return \Memcached::SERIALIZER_IGBINARY;
-						} else {
-							throw new CacheException('Error: You have not compiled Memcached with igbinary support!');
-						}
-					}
-				} else {
+				if (!extension_loaded('igbinary')) {
 					throw new CacheException('Error: The igbinary extension is not loaded!');
 				}
-			case self::SERIALIZER_NONE:
-				if ($this->isRedis === true) {
-					return \Redis::SERIALIZER_NONE;
-				} else {
-					throw new CacheException('Error: Disabled serialization is not available on Memcached!');
+
+				switch (nZEDb_CACHE_TYPE) {
+					case self::TYPE_REDIS:
+						// No way to check since phpredis has no constants or functions for this.
+						return \Redis::SERIALIZER_IGBINARY;
+					case self::TYPE_MEMCACHED:
+						if (\Memcached::HAVE_IGBINARY > 0) {
+							return \Memcached::SERIALIZER_IGBINARY;
+						}
+						throw new CacheException('Error: You have not compiled Memcached with igbinary support!');
+					case self::TYPE_APC: // No way to check, since apc.serializer can not be fetched using ini_get.
+					default:
+						return null;
 				}
+				break;
+
+			case self::SERIALIZER_NONE:
+				// Only redis supports this.
+				if (nZEDb_CACHE_TYPE != self::TYPE_REDIS) {
+					throw new CacheException('Error: Disabled serialization is only available on Redis!');
+				}
+				return \Redis::SERIALIZER_NONE;
+
 			case self::SERIALIZER_PHP:
 			default:
-				if ($this->isRedis === true) {
-					return \Redis::SERIALIZER_PHP;
-				} else {
-					return \Memcached::SERIALIZER_PHP;
+				switch (nZEDb_CACHE_TYPE) {
+					case self::TYPE_REDIS:
+						return \Redis::SERIALIZER_PHP;
+					case self::TYPE_MEMCACHED:
+						return \Memcached::SERIALIZER_PHP;
+					default:
+						return null;
 				}
 		}
 	}

--- a/www/automated.config.php
+++ b/www/automated.config.php
@@ -71,7 +71,7 @@ $settings_file = __DIR__ . DS . 'settings.php';
 if (is_file($settings_file)) {
 	require_once($settings_file);
 	if (php_sapi_name() == 'cli') {
-		$current_settings_file_version = 2; // Update this when updating settings.php.example
+		$current_settings_file_version = 3; // Update this when updating settings.php.example
 		if (!defined('nZEDb_SETTINGS_FILE_VERSION') || nZEDb_SETTINGS_FILE_VERSION != $current_settings_file_version) {
 			echo ("\033[0;31mNotice: Your $settings_file file is either out of date or you have not updated" .
 				" nZEDb_SETTINGS_FILE_VERSION to $current_settings_file_version in that file.\033[0m" . PHP_EOL

--- a/www/settings.php.example
+++ b/www/settings.php.example
@@ -15,9 +15,9 @@
  *
  * @note Developers: When updating settings.php.example, up this version
  *                   and $current_settings_file_version in automated.config.php
- * @version 2
+ * @version 3
  */
-define('nZEDb_SETTINGS_FILE_VERSION', 2);
+define('nZEDb_SETTINGS_FILE_VERSION', 3);
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////// Web Settings //////////////////////////////////////////////////////////
@@ -160,10 +160,14 @@ define('nZEDb_RENAME_MUSIC_MEDIAINFO', true);
  * 0 - disabled   ; No cache server(s) will be used.
  * 1 - memcached  ; Memcached server(s) will be used for caching.
  * 2 - redis      ; Redis server(s) will be used for caching.
+ * 3 - apc/apcu   ; APC or APCu will be used for caching.
  *
- * @note We use the Redis extension by nicolasff.
- * @see https://github.com/nicolasff/phpredis
+ * @note Memcahed: The Memcached PHP extension must be installed.
+ * @note Redis:    We use the Redis PHP extension by nicolasff. https://github.com/nicolasff/phpredis
+ * @note APC:      The APC or APCu PHP extension must be installed.
+ * @note APC:      Ignore these settings: nZEDb_CACHE_HOSTS / nZEDb_CACHE_SOCKET_FILE / nZEDb_CACHE_TIMEOUT
  * @default 0
+ * @version 3
  */
 define('nZEDb_CACHE_TYPE', 0);
 
@@ -217,15 +221,19 @@ define('nZEDb_CACHE_TIMEOUT', 10);
 define('nZEDb_CACHE_COMPRESSION', false);
 
 /**
- * 0 - Use the PHP serializer.
- * 1 - [Requires igbinary] Use igbinary serializer which is faster and uses less memory, works on both Memcached and Redis.
+ * Serialization is a way of converting data in PHP into strings of text which can be stored on the cache server.
+ *
+ * 0 - Use the PHP serializer. Recommended for most people.
+ * 1 - [Requires igbinary] Use igbinary serializer which is faster and uses less memory, works
+ *                         on Memcached / Redis / APC, read the notes below.
  * 2 - [Redis Only] Use no serializer.
  *
  * @note igbinary must be compiled and enabled in php.ini
  * @note Memcached/Redis must be compiled with igbinary support as well to use igbinary.
+ * @note Read the igbinary page how to compile / enable.
  * @see https://github.com/phadej/igbinary
- * @see https://github.com/nicolasff/phpredis
  * @default 0
+ * @version 3
  */
 define('nZEDb_CACHE_SERIALIZER', 0);
 

--- a/www/settings.php.example
+++ b/www/settings.php.example
@@ -544,6 +544,8 @@ define('PHPMAILER_SMTP_PASSWORD', '');
 //////////////////////////////////////////////// Change log ////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+2015-06-11       v3  Add support for APC or APCu extensions for caching data. Search for @version 3 for the changes.
+
 2015-05-10       v2  Update path to find_password_hash_cost.php in comments. Search for @version 2 for the changes.
 
 2015-05-03       v1  Track settings.php.example changes.


### PR DESCRIPTION
In PHP 5.5, APC is split into APCu (data caching) and Opcache (opcode caching) extensions.

APCu uses the same functions as APC: https://php.net/manual/en/ref.apc.php

Example installable package for the APCu extension:

https://packages.debian.org/sid/php5-apcu
http://packages.ubuntu.com/trusty/php5-apcu
https://www.archlinux.org/packages/extra/x86_64/php-apcu/