### PR TITLE
Add link to guide, remove serialization.

### DIFF
--- a/nzedb/libraries/Cache.php
+++ b/nzedb/libraries/Cache.php
@@ -350,7 +350,12 @@ class Cache
 							return \Memcached::SERIALIZER_IGBINARY;
 						}
 						throw new CacheException('Error: You have not compiled Memcached with igbinary support!');
-					case self::TYPE_APC: // No way to check, since apc.serializer can not be fetched using ini_get.
+					case self::TYPE_APC:
+						$setting = ini_get('apc.serializer');
+						if (!$setting || strtolower($setting) != 'igbinary') {
+							throw new CacheException('Error: You have not set apc.serializer=igbinary in php.ini!');
+						}
+						return null;
 					default:
 						return null;
 				}

--- a/nzedb/libraries/Cache.php
+++ b/nzedb/libraries/Cache.php
@@ -340,7 +340,10 @@ class Cache
 
 				switch (nZEDb_CACHE_TYPE) {
 					case self::TYPE_REDIS:
-						// No way to check since phpredis has no constants or functions for this.
+						// If this is not defined, it means phpredis was not compiled with --enable-redis-igbinary
+						if (!defined('\Redis::SERIALIZER_IGBINARY')) {
+							throw new CacheException('Error: phpredis was not compiled with igbinary support!');
+						}
 						return \Redis::SERIALIZER_IGBINARY;
 					case self::TYPE_MEMCACHED:
 						if (\Memcached::HAVE_IGBINARY > 0) {

--- a/nzedb/libraries/Cache.php
+++ b/nzedb/libraries/Cache.php
@@ -350,12 +350,7 @@ class Cache
 							return \Memcached::SERIALIZER_IGBINARY;
 						}
 						throw new CacheException('Error: You have not compiled Memcached with igbinary support!');
-					case self::TYPE_APC:
-						$setting = ini_get('apc.serializer');
-						if (!$setting || strtolower($setting) != 'igbinary') {
-							throw new CacheException('Error: You have not set apc.serializer=igbinary in php.ini!');
-						}
-						return null;
+					case self::TYPE_APC: // Ignore - set by apc.serializer setting.
 					default:
 						return null;
 				}

--- a/www/settings.php.example
+++ b/www/settings.php.example
@@ -162,6 +162,7 @@ define('nZEDb_RENAME_MUSIC_MEDIAINFO', true);
  * 2 - redis      ; Redis server(s) will be used for caching.
  * 3 - apc/apcu   ; APC or APCu will be used for caching.
  *
+ * @see https://github.com/nZEDb/nZEDb_Misc/blob/master/Guides/Various/Cache/Guide.md
  * @note Memcahed: The Memcached PHP extension must be installed.
  * @note Redis:    We use the Redis PHP extension by nicolasff. https://github.com/nicolasff/phpredis
  * @note APC:      The APC or APCu PHP extension must be installed.

--- a/www/settings.php.example
+++ b/www/settings.php.example
@@ -230,6 +230,7 @@ define('nZEDb_CACHE_COMPRESSION', false);
  * 2 - [Redis Only] Use no serializer.
  *
  * @note igbinary must be compiled and enabled in php.ini
+ * @note APC/APCu: This setting is ignored, set this in php.ini with apc.serializer
  * @note Memcached/Redis must be compiled with igbinary support as well to use igbinary.
  * @note Read the igbinary page how to compile / enable.
  * @see https://github.com/phadej/igbinary


### PR DESCRIPTION
Add link to new guide for cache servers / igbinary: https://github.com/nZEDb/nZEDb_Misc/blob/master/Guides/Various/Cache/Guide.md

The extensions already handle serialization (poorly documented), so no need for us to do it.

Add checks for igbinary for Redis and APC.

Fix a typo causing APC not to load.