### PR TITLE
NZBImport add inactive group instead of skipping nzb.

### DIFF
--- a/nzedb/NZBImport.php
+++ b/nzedb/NZBImport.php
@@ -3,6 +3,7 @@ namespace nzedb;
 
 use nzedb\db\Settings;
 use nzedb\utility\Utility;
+use nzedb\Groups;
 
 /**
  * Import NZB files into the database.
@@ -85,6 +86,13 @@ class NZBImport
 	public $nzb;
 
 	/**
+	 * Access point to add new groups.
+	 *
+	 * @var Groups $groups
+	 */
+	private $groups;
+
+	/**
 	 * Construct.
 	 *
 	 * @param array $options Class instances / various options.
@@ -116,6 +124,7 @@ class NZBImport
 		$this->crossPostt = ($this->pdo->getSetting('crossposttime') != '') ? $this->pdo->getSetting('crossposttime') : 2;
 		$this->browser = $options['Browser'];
 		$this->retVal = '';
+		$this->groups = new Groups(['Settings' => $this->pdo]);
 	}
 
 	/**
@@ -290,6 +299,19 @@ class NZBImport
 						if (!$groupName) {
 							$groupName = $group;
 						}
+					} else {
+						$groupID = $this->groups->add([
+							'name' => $group,
+							'description' => 'Added via import',
+							'backfill_target' => 0,
+							'first_record' => 0,
+							'last_record' => 0,
+							'active' => 0,
+							'backfill' => 0
+						]);
+						$this->allGroups[$group] = $groupID;
+
+						$this->echoOut("Adding missing group: ($group)");
 					}
 				}
 				// Add all the found groups to an array.


### PR DESCRIPTION
When the NZBImport process runs, it will skip an NZB if the group it refers to doesn't exist in your database. (not just not-active, completely non-existent). 

This PR adds the ability for NZBImport to add the missing group so the NZB can be processed successfully. It adds it as inactive, no backfill, with a description that reflects how/why it was added.