### PR TITLE
Dev terbonium cbp delete fix (resubmitted, first code check failed)

### DIFF
--- a/nzedb/processing/ProcessReleases.php
+++ b/nzedb/processing/ProcessReleases.php
@@ -417,29 +417,28 @@ class ProcessReleases
 		foreach ($groupIDs as $groupID) {
 			if ($this->pdo->queryOneRow(
 					sprintf(
-						'SELECT SQL_NO_CACHE id FROM %s WHERE filecheck = %d AND filesize > 0 AND group_id = %d LIMIT 1',
+						'SELECT SQL_NO_CACHE id FROM %s c WHERE c.filecheck = %d AND c.filesize > 0 %s LIMIT 1',
 						$group['cname'],
 						self::COLLFC_SIZED,
-						$groupID['id']
+						$this->tablePerGroup === false ? sprintf('AND c.group_id = %d', $groupID['id']) : ''
 					)
 				) !== false
 			) {
 				$deleteQuery = $this->pdo->queryExec(
 					sprintf('
 						DELETE c, b, p FROM %s c
-						INNER JOIN %s b ON (c.id=b.collection_id)
-						STRAIGHT_JOIN %s p ON (b.id=p.binaryid)
-						INNER JOIN groups g ON g.id = c.group_id
-						WHERE c.group_id = %d
-						AND c.filecheck = %d
+						LEFT JOIN %s b ON (c.id=b.collection_id)
+						LEFT JOIN %s p ON (b.id=p.binaryid)
+						LEFT JOIN groups g ON g.id = c.group_id
+						WHERE c.filecheck = %d %s
 						AND c.filesize > 0
 						AND greatest(IFNULL(g.minsizetoformrelease, 0), %d) > 0
 						AND c.filesize < greatest(IFNULL(g.minsizetoformrelease, 0), %d)',
 						$group['cname'],
 						$group['bname'],
 						$group['pname'],
-						$groupID['id'],
 						self::COLLFC_SIZED,
+						$this->tablePerGroup === false ? sprintf('AND c.group_id = %d', $groupID['id']) : '',
 						$minSizeSetting,
 						$minSizeSetting
 					)
@@ -453,16 +452,15 @@ class ProcessReleases
 					$deleteQuery = $this->pdo->queryExec(
 						sprintf('
 							DELETE c, b, p FROM %s c
-							INNER JOIN %s b ON (c.id=b.collection_id)
-							STRAIGHT_JOIN %s p ON (b.id=p.binaryid)
-							WHERE c.filecheck = %d
-							AND c.group_id = %d
+							LEFT JOIN %s b ON (c.id=b.collection_id)
+							LEFT JOIN %s p ON (b.id=p.binaryid)
+							WHERE c.filecheck = %d %s
 							AND c.filesize > %d',
 							$group['cname'],
 							$group['bname'],
 							$group['pname'],
 							self::COLLFC_SIZED,
-							$groupID['id'],
+							$this->tablePerGroup === false ? sprintf('AND c.group_id = %d', $groupID['id']) : '',
 							$maxSizeSetting
 						)
 					);
@@ -474,18 +472,17 @@ class ProcessReleases
 				$deleteQuery = $this->pdo->queryExec(
 					sprintf('
 						DELETE c, b, p FROM %s c
-						INNER JOIN %s b ON (c.id=b.collection_id)
-						STRAIGHT_JOIN %s p ON (b.id=p.binaryid)
-						INNER JOIN groups g ON g.id = c.group_id
-						WHERE c.group_id = %d
-						AND c.filecheck = %d
+						LEFT JOIN %s b ON (c.id=b.collection_id)
+						LEFT JOIN %s p ON (b.id=p.binaryid)
+						JOIN groups g ON g.id = c.group_id
+						WHERE c.filecheck = %d %s
 						AND greatest(IFNULL(g.minfilestoformrelease, 0), %d) > 0
 						AND c.totalfiles < greatest(IFNULL(g.minfilestoformrelease, 0), %d)',
 						$group['cname'],
 						$group['bname'],
 						$group['pname'],
-						$groupID['id'],
 						self::COLLFC_SIZED,
+						$this->tablePerGroup === false ? sprintf('AND c.group_id = %d', $groupID['id']) : '',
 						$minFilesSetting,
 						$minFilesSetting
 					)
@@ -1030,8 +1027,15 @@ class ProcessReleases
 				$deleted++;
 				$this->pdo->queryExec(
 					sprintf('
-						DELETE c FROM %s c WHERE c.id = %d',
-						$group['cname'], $collection['id']
+						DELETE c, b, p
+						FROM %s c
+						LEFT JOIN %s b ON(c.id=b.collection_id)
+						LEFT JOIN %s p ON(b.id=p.binaryid)
+						WHERE c.id = %d',
+						$group['cname'],
+						$group['bname'],
+						$group['pname'],
+						$collection['id']
 					)
 				);
 			}

--- a/resources/db/patches/mysql/+1~collections.sql
+++ b/resources/db/patches/mysql/+1~collections.sql
@@ -1,0 +1,29 @@
+# improve performance of CBP cleanup of OLD collections 
+# nzedb/processing/ProcessReleases.php L1639-L1648
+DROP PROCEDURE IF EXISTS tpg_change;
+
+DELIMITER $$
+CREATE PROCEDURE tpg_change()
+BEGIN
+  DECLARE done INT DEFAULT false;
+  DECLARE _table CHAR(255);
+  DECLARE _stmt VARCHAR(1000);
+  DECLARE cur1 CURSOR FOR
+    SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES
+    WHERE TABLE_SCHEMA = DATABASE()
+    AND (TABLE_NAME LIKE "collections\_%" OR TABLE_NAME="collections");
+  DECLARE CONTINUE HANDLER FOR NOT FOUND SET done = TRUE;
+  OPEN cur1;
+    myloop: loop FETCH cur1 INTO _table;
+      IF done THEN LEAVE myloop; END IF;
+      SET @sql1 := CONCAT("ALTER TABLE ", _table," ADD INDEX ix_collection_added(added)");
+      PREPARE _stmt FROM @sql1;
+      EXECUTE _stmt;
+      DROP PREPARE _stmt;
+    END loop;
+  CLOSE cur1;
+END $$
+DELIMITER ;
+
+CALL tpg_change();
+DROP PROCEDURE tpg_change;


### PR DESCRIPTION
added index to collections.added column needed for DELETING collections past collection_timeout

use left joins for CBP clean up to force proper join order and so that
we don't skip collections or binaries that happen to have no binaries or
parts.

don't use WHERE c.group_id = when using TPG tables in DELETES.