### PR TITLE
Fix tmux example config for tmux v1.8. 

### DIFF
--- a/misc/update/nix/tmux/powerline/tmux.example.conf
+++ b/misc/update/nix/tmux/powerline/tmux.example.conf
@@ -1,7 +1,5 @@
 # Common tmux configuration settings.
 # Copy this example file to tmux.conf and make any local changes there.
-#
-if-shell "[[ `tmux -V` > 'tmux 2.0' ]]" "source-file tmux-2.1.conf" "source-file tmux-2.0.conf"
 
 # C-b is not acceptable -- Vim uses it
 set-option -g prefix C-a
@@ -43,3 +41,6 @@ set-window-option -g window-status-format "#[fg=colour114, bg=colour27]#[fg=colo
 
 #reduce memory and scrollback buffer
 set -g history-limit 1000
+
+# tmux version specific config - Should be last line of config
+if-shell "[[ `tmux -V` > 'tmux 2.0' ]]" "source-file tmux-2.1.conf" "source-file tmux-2.0.conf"

--- a/misc/update/nix/tmux/run.php
+++ b/misc/update/nix/tmux/run.php
@@ -96,10 +96,14 @@ if ($powerline == 1) {
 } else {
 	$tmuxconfig = $DIR . "update/nix/tmux/tmux.conf";
 }
+// Check local tmux config file exists
+if (!file_exists($tmuxconfig)) {
+    exit("Local copy of tmux.conf not found.\nCopy tmux.example.conf to tmux.conf and make any local changes as needed.\n");
+}
 
 if ($seq == 1) {
 	exec("cd ${DIR}/update/nix/tmux; tmux -f $tmuxconfig new-session -d -s $tmux_session -n Monitor 'printf \"\033]2;\"Monitor\"\033\"'");
-	exec("tmux selectp -t $tmux_session:0.0; tmux splitw -t $tmux_session:0 -h -p 67 'printf \"\033]2;update_releases\033\"'");
+	exec("tmux selectp -t $tmux_session:0.0; tmux splitw -t $tmux_session:0 -h -p 64 'printf \"\033]2;update_releases\033\"'");
 	exec("tmux selectp -t $tmux_session:0.0; tmux splitw -t $tmux_session:0 -v -p 25 'printf \"\033]2;nzb-import\033\"'");
 
 	window_utilities($tmux_session);
@@ -118,7 +122,7 @@ if ($seq == 1) {
 } else {
 	if ($seq == 2) {
 		exec("cd ${DIR}/update/nix/tmux; tmux -f $tmuxconfig new-session -d -s $tmux_session -n Monitor 'printf \"\033]2;\"Monitor\"\033\"'");
-		exec("tmux selectp -t $tmux_session:0.0; tmux splitw -t $tmux_session:0 -h -p 67 'printf \"\033]2;sequential\033\"'");
+		exec("tmux selectp -t $tmux_session:0.0; tmux splitw -t $tmux_session:0 -h -p 64 'printf \"\033]2;sequential\033\"'");
 		exec("tmux selectp -t $tmux_session:0.0; tmux splitw -t $tmux_session:0 -v -p 25 'printf \"\033]2;nzb-import\033\"'");
 
 		window_stripped_utilities($tmux_session);
@@ -136,7 +140,7 @@ if ($seq == 1) {
 		attach($DIR, $tmux_session);
 	} else {
 		exec("cd ${DIR}/update/nix/tmux; tmux -f $tmuxconfig new-session -d -s $tmux_session -n Monitor 'printf \"\033]2;Monitor\033\"'");
-		exec("tmux selectp -t $tmux_session:0.0; tmux splitw -t $tmux_session:0 -h -p 67 'printf \"\033]2;update_binaries\033\"'");
+		exec("tmux selectp -t $tmux_session:0.0; tmux splitw -t $tmux_session:0 -h -p 64 'printf \"\033]2;update_binaries\033\"'");
 		exec("tmux selectp -t $tmux_session:0.0; tmux splitw -t $tmux_session:0 -v -p 25 'printf \"\033]2;nzb-import\033\"'");
 		exec("tmux selectp -t $tmux_session:0.2; tmux splitw -t $tmux_session:0 -v -p 67 'printf \"\033]2;backfill\033\"'");
 		exec("tmux splitw -t $tmux_session -v -p 50 'printf \"\033]2;update_releases\033\"'");

--- a/misc/update/nix/tmux/tmux.example.conf
+++ b/misc/update/nix/tmux/tmux.example.conf
@@ -1,8 +1,6 @@
 # Common tmux configuration settings.
 # Copy this example file to tmux.conf and make any local changes there.
 
-if-shell "[[ `tmux -V` > 'tmux 2.0' ]]" "source-file tmux-2.1.conf" "source-file tmux-2.0.conf"
-
 # C-b is not acceptable -- Vim uses it
 set-option -g prefix C-a
 bind-key C-a last-window
@@ -70,3 +68,7 @@ set -g history-limit 1000
 
 # Keeps pane open after process ends
 set -g set-remain-on-exit on
+
+# tmux version specific config - Should be last line of config
+if-shell "[[ `tmux -V` > 'tmux 2.0' ]]" "source-file tmux-2.1.conf" "source-file tmux-2.0.conf"
+


### PR DESCRIPTION
Add test for existence of tmux.conf local copy.
Widen monitor pane, optional adjustment. Will back-out if causes issues.
Note: tmux v2.1 still unstable with nzedb.