### PR TITLE
Adding noscript support to recaptcha

### DIFF
--- a/www/themes/Default/templates/frontend/captcha.tpl
+++ b/www/themes/Default/templates/frontend/captcha.tpl
@@ -3,5 +3,26 @@
 	<script type="text/javascript"
 			src="https://www.google.com/recaptcha/api.js?hl=en">
 	</script>
+    <noscript>
+        <div style="width: 302px; height: 422px;">
+            <div style="width: 302px; height: 422px; position: relative;">
+                <div style="width: 302px; height: 422px; position: absolute;">
+                    <iframe src="https://www.google.com/recaptcha/api/fallback?k=your_site_key"
+                            frameborder="0" scrolling="no"
+                            style="width: 302px; height:422px; border-style: none;">
+                    </iframe>
+                </div>
+                <div style="width: 300px; height: 60px; border-style: none;
+                  bottom: 12px; left: 25px; margin: 0px; padding: 0px; right: 25px;
+                  background: #f9f9f9; border: 1px solid #c1c1c1; border-radius: 3px;">
+        <textarea id="g-recaptcha-response" name="g-recaptcha-response"
+                  class="g-recaptcha-response"
+                  style="width: 250px; height: 40px; border: 1px solid #c1c1c1;
+                         margin: 10px 25px; padding: 0px; resize: none;" >
+        </textarea>
+                </div>
+            </div>
+        </div>
+    </noscript>
 	<br/>
 {/if}


### PR DESCRIPTION
Some users have addons that block javascript. This tag will still allow recaptcha to work even if that's the case. 