### PR TITLE
Add docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,44 @@
+FROM ubuntu:14.04
+
+COPY ./misc/docker/nginx /etc/nginx/sites-available/nZEDb
+COPY ./misc/docker/init.sh /init.sh
+
+RUN apt-get install -y software-properties-common && \
+  add-apt-repository ppa:ondrej/php5-5.6 && \
+  add-apt-repository ppa:nginx/stable && \
+  apt-get update && \
+  apt-get install -y --force-yes \
+    software-properties-common \
+    python-software-properties \
+    git \
+    php5 \
+    php5-cli \
+    php5-dev \
+    php5-json \
+    php-pear \
+    php5-gd \
+    php5-mysqlnd \
+    php5-curl \
+    php5-fpm \
+    mariadb-client \
+    libmysqlclient-dev \
+    nginx \
+    p7zip-full \
+    unrar-free \
+    lame \
+    mediainfo \
+  && unlink /etc/nginx/sites-enabled/default \
+  && ln -s /etc/nginx/sites-available/nZEDb /etc/nginx/sites-enabled/nZEDb \
+  && git clone https://github.com/nZEDb/nZEDb.git /var/www/nZEDb \
+  && chmod -R 777 /var/lib/php5/sessions \
+  && chmod -R 777 /var/www/nZEDb/libs/smarty/templates_c \
+  && chmod -R 777 /var/www/nZEDb/resources \
+  && mkdir -p /var/www/nZEDb/nzedb/config \
+  && chmod -R 777 /var/www/nZEDb/nzedb/config \
+  && chmod -R 777 /var/www/nZEDb/www \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+EXPOSE 80
+
+ENTRYPOINT ["/init.sh"]

--- a/misc/docker/init.sh
+++ b/misc/docker/init.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+php5-fpm -c /etc/php5/fpm
+nginx -g 'daemon off;'

--- a/misc/docker/nginx
+++ b/misc/docker/nginx
@@ -1,0 +1,53 @@
+server {
+    # Change these settings to match your machine.
+    listen 80 default_server;
+    server_name localhost;
+
+    # These are the log locations, you should not have to change these.
+    access_log /var/log/nginx/access.log;
+    error_log /var/log/nginx/error.log;
+
+    # This is the root web folder for nZEDb, you shouldn't have to change this.
+    root /var/www/nZEDb/www/;
+    index index.html index.htm index.php;
+
+    # Everything below this should not be changed unless noted.
+    location ~* \.(?:css|eot|gif|gz|ico|inc|jpe?g|js|ogg|oga|ogv|mp4|m4a|mp3|png|svg|ttf|txt|woff|xml)$ {
+        expires max;
+        add_header Pragma public;
+        add_header Cache-Control "public, must-revalidate, proxy-revalidate";
+    }
+
+    location / {
+        try_files $uri $uri/ @rewrites;
+    }
+
+    location ^~ /covers/ {
+        # This is where the nZEDb covers folder should be in.
+        root /var/www/nZEDb/resources;
+    }
+
+    location @rewrites {
+        rewrite ^/([^/\.]+)/([^/]+)/([^/]+)/? /index.php?page=$1&id=$2&subpage=$3 last;
+        rewrite ^/([^/\.]+)/([^/]+)/?$ /index.php?page=$1&id=$2 last;
+        rewrite ^/([^/\.]+)/?$ /index.php?page=$1 last;
+    }
+
+    location /admin {
+    }
+
+    location /install {
+    }
+
+    location ~ \.php$ {
+        include /etc/nginx/fastcgi_params;
+
+        # Uncomment the following line and comment the .sock line if you want to use TCP.
+        #fastcgi_pass 127.0.0.1:9000;
+        fastcgi_pass unix:/var/run/php5-fpm.sock;
+
+        # The next two lines should go in your fastcgi_params
+        fastcgi_index index.php;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+    }
+}


### PR DESCRIPTION
Example usage with docker-compose

``` yml
nzedb:
  build: .
  restart: always
  links:
    - db:db
  ports:
    - "3000:80"

db:
  image: mariadb
  restart: always
  environment:
    MYSQL_PASSWORD: superSecretRootPassword
    MYSQL_ROOT_PASSWORD: myDbPassword
    MYSQL_USER: nzedb
    MYSQL_DATABASE: nzedb

# docker-compose up
```

Database hostname would be `db`
