### PR TITLE
Removing extraneous container divs for bootstrap 3 upgrade

### DIFF
--- a/www/themes/Alpha/templates/basepage.tpl
+++ b/www/themes/Alpha/templates/basepage.tpl
@@ -287,7 +287,11 @@
 												   improve your experience.</p>
 							<![endif]-->
 
-							{$page->content}
+							<div class="row">
+								<div class="col-sm-12">
+									{$page->content}
+								</div>
+							</div>
 
 						</div><!--/.grey-box -->
 					</div><!--/.grey-frame -->

--- a/www/themes/Alpha/templates/books.tpl
+++ b/www/themes/Alpha/templates/books.tpl
@@ -26,7 +26,7 @@
 </div>
 {if $results|@count > 0}
 	<form id="nzb_multi_operations_form" action="get">
-		<div class="container nzb_multi_operations" style="text-align:right;margin-bottom:5px;">
+		<div class="nzb_multi_operations" style="text-align:right;margin-bottom:5px;">
 			View:
 			<span><i class="icon-th-list"></i></span>
 			&nbsp;&nbsp;

--- a/www/themes/Alpha/templates/browse.tpl
+++ b/www/themes/Alpha/templates/browse.tpl
@@ -25,7 +25,7 @@
 {/if} *}
 {if $results|@count > 0}
 	<form id="nzb_multi_operations_form" action="get">
-		<div class="container nzb_multi_operations" style="text-align:right;margin-bottom:5px;">
+		<div class="nzb_multi_operations" style="text-align:right;margin-bottom:5px;">
 			{if $covgroup != ''}View:
 				<a href="{$smarty.const.WWW_TOP}/{$covgroup}?t={$category}">
 					<i class="icon-th-list"></i>

--- a/www/themes/Alpha/templates/cart.tpl
+++ b/www/themes/Alpha/templates/cart.tpl
@@ -1,10 +1,10 @@
 {if $results|@count > 0}
-	<div class="container">
+
 		<div class="pull-left"><i class="icon-rss-sign icon-2x" style="color:orange;"></i> Download your cart as an <a href="{$smarty.const.WWW_TOP}/rss?t=-2&amp;dl=1&amp;i={$userdata.id}&amp;r={$userdata.rsstoken}&amp;del=1">Rss Feed</a>.</div>
-	</div>
+
 	<br>
 	<form id="nzb_multi_operations_form" action="get">
-		<div class="container nzb_multi_operations text-right" style="margin-bottom:5px;">
+		<div class="nzb_multi_operations text-right" style="margin-bottom:5px;">
 			With Selected: <button type="button" class="btn btn-danger btn-sm nzb_multi_operations_cartdelete">Delete</button>
 		</div>
 
@@ -36,4 +36,3 @@
 {else}
 	<h2>No NZBs in cart</h2>
 {/if}
-</div>

--- a/www/themes/Alpha/templates/console.tpl
+++ b/www/themes/Alpha/templates/console.tpl
@@ -26,7 +26,7 @@
 </div>
 {if $results|@count > 0}
 	<form id="nzb_multi_operations_form" action="get">
-		<div class="container nzb_multi_operations" style="text-align:right;margin-bottom:5px;">
+		<div class="nzb_multi_operations" style="text-align:right;margin-bottom:5px;">
 			View:
 			<span><i class="icon-th-list"></i></span>
 			&nbsp;&nbsp;
@@ -97,13 +97,13 @@
 								><img src="{$smarty.const.WWW_TOP}/themes/shared/img/icons/gamespot.png"></a>
 							</div>
 							<hr>
-							<div class="container">
+
 								<a
 									class="label label-info"
 									href="{$smarty.const.WWW_TOP}/console?platform={$result.platform}"
 									title="View similar nzbs"
 								>Similar</a>
-							</div>
+
 						</div>
 					</td>
 					<td colspan="8" class="left" id="guid{$result.guid}">

--- a/www/themes/Alpha/templates/contact.tpl
+++ b/www/themes/Alpha/templates/contact.tpl
@@ -1,4 +1,4 @@
-<div class="container">
+
 	<div class="col-sm-6 col-sm-offset-3">
 		<div class="well">
 			{$msg} {* This is a message that appears if a email is sent. *}
@@ -31,4 +31,3 @@
 			{/if}
 		</div>
 	</div>
-</div><!-- container -->

--- a/www/themes/Alpha/templates/forgottenpassword.tpl
+++ b/www/themes/Alpha/templates/forgottenpassword.tpl
@@ -4,7 +4,7 @@
 
 {if $confirmed == '' && $sent == ''}
 
-	<div class="container">
+
 		<div class="col-sm-6 col-sm-offset-3">
 			<div class="well">
 				<form class="form-signin" action="forgottenpassword?action=submit" method="post">
@@ -20,7 +20,6 @@
 				</form>
 			</div>
 		</div>
-	</div>
 	</div>
 {elseif $sent != ''}
 	<p>

--- a/www/themes/Alpha/templates/games.tpl
+++ b/www/themes/Alpha/templates/games.tpl
@@ -26,7 +26,7 @@
 </div>
 {if $results|@count > 0}
 	<form id="nzb_multi_operations_form" action="get">
-		<div class="container nzb_multi_operations" style="text-align:right;margin-bottom:5px;">
+		<div class="nzb_multi_operations" style="text-align:right;margin-bottom:5px;">
 			View:
 			<span><i class="icon-th-list"></i></span>
 			&nbsp;&nbsp;

--- a/www/themes/Alpha/templates/login.tpl
+++ b/www/themes/Alpha/templates/login.tpl
@@ -1,7 +1,7 @@
 {if $error != ''}
 	<div class="alert alert-danger">{$error}</div>
 {/if}
-<div class="container">
+
 	<div class="col-sm-6 col-sm-offset-3">
 		<div class="well">
 			<form class="form-signin" action="login" method="post">
@@ -26,4 +26,3 @@
 			</form>
 		</div>
 	</div>
-</div>

--- a/www/themes/Alpha/templates/movies.tpl
+++ b/www/themes/Alpha/templates/movies.tpl
@@ -26,7 +26,7 @@
 </div>
 {if $results|@count > 0}
 	<form id="nzb_multi_operations_form" action="get">
-	<div class="container nzb_multi_operations" style="text-align:right;margin-bottom:5px;">
+	<div class="nzb_multi_operations" style="text-align:right;margin-bottom:5px;">
 		View:
 		<span><i class="icon-th-list"></i></span>
 		&nbsp;&nbsp;

--- a/www/themes/Alpha/templates/multi-operations.tpl
+++ b/www/themes/Alpha/templates/multi-operations.tpl
@@ -1,4 +1,4 @@
-<div class="container nzb_multi_operations">
+<div class="nzb_multi_operations">
 	{if $pager}
 		{$pager}
 	{/if}

--- a/www/themes/Alpha/templates/music.tpl
+++ b/www/themes/Alpha/templates/music.tpl
@@ -26,7 +26,7 @@
 </div>
 {if $results|@count > 0}
 	<form id="nzb_multi_operations_form" action="get">
-	<div class="container nzb_multi_operations" style="text-align:right;margin-bottom:5px;">
+	<div class="nzb_multi_operations" style="text-align:right;margin-bottom:5px;">
 		View:
 		<span><i class="icon-th-list"></i></span>
 		&nbsp;&nbsp;

--- a/www/themes/Alpha/templates/predb.tpl
+++ b/www/themes/Alpha/templates/predb.tpl
@@ -17,7 +17,7 @@
 		</span>
 	</div>
 </form>
-<div class="container">
+
 	{$pager}
 	<table style="margin-bottom:10px; margin-top:5px;" class="table table-condensed table-highlight table-striped data Sortable">
 		<thead>
@@ -259,4 +259,3 @@
 		</tbody>
 	</table>
 	{$pager}
-</div>

--- a/www/themes/Alpha/templates/register.tpl
+++ b/www/themes/Alpha/templates/register.tpl
@@ -3,7 +3,6 @@
 {/if}
 
 {if $showregister != "0"}
-	<div class="container">
 	<div class="col-sm-6 col-sm-offset-3">
 		<div class="well">
 			<form class="form-signin" action="register?action=submit{$invite_code_query}" method="post">
@@ -46,6 +45,5 @@
 				<button class="btn btn-default" type="submit" value="Register">Register</button>
 			</form>
 		</div>
-	</div>
 	</div>
 {/if}

--- a/www/themes/Alpha/templates/search.tpl
+++ b/www/themes/Alpha/templates/search.tpl
@@ -107,7 +107,7 @@
 {elseif ($search || $subject || $searchadvr || $searchadvsubject || $searchadvfilename || $selectedgroup || $selectedsizefrom || $searchadvdaysold) == ""}
 {else}
 	<form id="nzb_multi_operations_form" method="get" action="{$smarty.const.WWW_TOP}/search">
-		<div class="container nzb_multi_operations" style="text-align:right;margin-bottom:5px;">
+		<div class="nzb_multi_operations" style="text-align:right;margin-bottom:5px;">
 			{if $covgroup != ''}View:
 				<a href="{$smarty.const.WWW_TOP}/{$covgroup}?t={$category}">
 					<i class="icon-th-list"></i>

--- a/www/themes/Alpha/templates/viewanime.tpl
+++ b/www/themes/Alpha/templates/viewanime.tpl
@@ -31,7 +31,7 @@
 			{if animePicture != ""}<img class="shadow img-thumbnail" alt="{$animeTitle} Picture" src="{$smarty.const.WWW_TOP}/covers/anime/{$animeAnidbID}.jpg" />{/if}
 		</div>
 		<form id="nzb_multi_operations_form" action="get">
-			<div class="container nzb_multi_operations text-right" style="padding-bottom: 4px;">
+			<div class="nzb_multi_operations text-right" style="padding-bottom: 4px;">
 				View:
 				<span><i class="icon-th-list"></i></span>&nbsp;&nbsp;
 				<a href="{$smarty.const.WWW_TOP}/browse?t=5070"><i class="icon-align-justify"></i></a>

--- a/www/themes/Alpha/templates/viewnzb.tpl
+++ b/www/themes/Alpha/templates/viewnzb.tpl
@@ -12,7 +12,6 @@
 
 <h2>{$release.searchname|escape:"htmlall"|truncate:100:"...":true}{if $failed != NULL && $failed > 0}<span class="btn btn-default btn-xs" title="This release has failed to download for some users">
 		<i class ="fa fa-thumbs-o-up"></i> {$release.grabs} Grab{if $release.grabs != 1}s{/if} / <i class ="fa fa-thumbs-o-down"></i> {$failed} Failed Download{if $failed != 1}s{/if}</span>{/if}</h2><br>
-<div class="container">
 	<div class="col-xs-8">
 		<span class="label label-default">{$release.category_name}</span> <span class="label label-default">{$release.group_name}</span>
 		<br />
@@ -274,7 +273,6 @@
 		{if $boo && $boo.cover == 1}<img class="shadow img-thumbnail" style="vertical-align:top" src="{$smarty.const.WWW_TOP}/covers/book/{$boo.id}.jpg" alt="{$boo.title|escape:"htmlall"}">{/if}
 		{*{$smarty.const.WWW_TOP}/covers/book/{$boo.id}.jpg" width="160" alt="{$boo.title|escape:"htmlall"}*}
 	</div>
-</div>
 <br>        <br>
 
 <table class="table table-condensed table-striped data">

--- a/www/themes/Alpha/templates/xxx.tpl
+++ b/www/themes/Alpha/templates/xxx.tpl
@@ -26,7 +26,7 @@
 </div>
 {if $results|@count > 0}
 	<form id="nzb_multi_operations_form" action="get">
-	<div class="container nzb_multi_operations" style="text-align:right;margin-bottom:5px;">
+	<div class="nzb_multi_operations" style="text-align:right;margin-bottom:5px;">
 		View:
 		<span><i class="icon-th-list"></i></span>
 		&nbsp;&nbsp;


### PR DESCRIPTION
Bootstrap 3 does not like nested container divs. Instead there should only be 1 in base page and all others should be removed and put inside "row" divs instead if necessary. 