### PR TITLE
Moving ad display to a partial for Alpha theme to unify look and functionality.

### DIFF
--- a/www/themes/Alpha/templates/books.tpl
+++ b/www/themes/Alpha/templates/books.tpl
@@ -1,12 +1,5 @@
-{if {$site->adbrowse} != ''}
-	<div class="container" style="width:500px;">
-		<fieldset class="adbanner div-center">
-			<legend class="adbanner">Advertisement</legend>
-			{$site->adbrowse}
-		</fieldset>
-	</div>
-	<br>
-{/if}
+{include file='partials/ads.tpl' ad=$site->adbrowse}
+
 <div class="panel">
 	<div class="panel-heading">
 		<h4 class="panel-title">

--- a/www/themes/Alpha/templates/browse.tpl
+++ b/www/themes/Alpha/templates/browse.tpl
@@ -1,11 +1,4 @@
-{if {$site->adbrowse} != ''}
-	<div class="container" style="width:500px;">
-		<fieldset class="adbanner div-center">
-			<legend class="adbanner">Advertisement</legend>
-			{$site->adbrowse}
-		</fieldset></div>
-	<br>
-{/if}
+{include file='partials/ads.tpl' ad=$site->adbrowse}
 {* {if $covergrp != ''}
 <div class="accordion" id="searchtoggle">
 	<div class="accordion-group">

--- a/www/themes/Alpha/templates/browsegroup.tpl
+++ b/www/themes/Alpha/templates/browsegroup.tpl
@@ -1,12 +1,4 @@
-{if {$site->adbrowse} != ''}
-	<div class="container" style="width:500px;">
-		<fieldset class="adbanner div-center">
-			<legend class="adbanner">Advertisement</legend>
-			{$site->adbrowse}
-		</fieldset>
-	</div>
-	<br>
-{/if}
+{include file='partials/ads.tpl' ad=$site->adbrowse}
 {if $results|@count > 0}
 	<table class="table-striped table-condensed table-highlight data Sortable table" id="browsetable">
 		<thead>

--- a/www/themes/Alpha/templates/console.tpl
+++ b/www/themes/Alpha/templates/console.tpl
@@ -1,12 +1,4 @@
-{if {$site->adbrowse} != ''}
-	<div class="container" style="width:500px;">
-		<fieldset class="adbanner div-center">
-			<legend class="adbanner">Advertisement</legend>
-			{$site->adbrowse}
-		</fieldset>
-	</div>
-	<br>
-{/if}
+{include file='partials/ads.tpl' ad=$site->adbrowse}
 <div class="panel">
 	<div class="panel-heading">
 		<h4 class="panel-title">

--- a/www/themes/Alpha/templates/games.tpl
+++ b/www/themes/Alpha/templates/games.tpl
@@ -1,12 +1,4 @@
-{if {$site->adbrowse} != ''}
-	<div class="container" style="width:500px;">
-		<fieldset class="adbanner div-center">
-			<legend class="adbanner">Advertisement</legend>
-			{$site->adbrowse}
-		</fieldset>
-	</div>
-	<br>
-{/if}
+{include file='partials/ads.tpl' ad=$site->adbrowse}
 <div class="panel">
 	<div class="panel-heading">
 		<h4 class="panel-title">

--- a/www/themes/Alpha/templates/movies.tpl
+++ b/www/themes/Alpha/templates/movies.tpl
@@ -1,12 +1,4 @@
-{if {$site->adbrowse} != ''}
-	<div class="container" style="width:500px;">
-		<fieldset class="adbanner div-center">
-			<legend class="adbanner">Advertisement</legend>
-			{$site->adbrowse}
-		</fieldset>
-	</div>
-	<br>
-{/if}
+{include file='partials/ads.tpl' ad=$site->adbrowse}
 <div class="panel">
 	<div class="panel-heading">
 		<h4 class="panel-title">

--- a/www/themes/Alpha/templates/music.tpl
+++ b/www/themes/Alpha/templates/music.tpl
@@ -1,12 +1,4 @@
-{if {$site->adbrowse} != ''}
-	<div class="container" style="width:500px;">
-		<fieldset class="adbanner div-center">
-			<legend class="adbanner">Advertisement</legend>
-			{$site->adbrowse}
-		</fieldset>
-	</div>
-	<br>
-{/if}
+{include file='partials/ads.tpl' ad=$site->adbrowse}
 <div class="panel">
 	<div class="panel-heading">
 		<h4 class="panel-title">

--- a/www/themes/Alpha/templates/partials/_ad.tpl
+++ b/www/themes/Alpha/templates/partials/_ad.tpl
@@ -1,0 +1,4 @@
+<fieldset class="adbanner center-block">
+	<legend class="adbanner">Advertisement</legend>
+	{$ad}
+</fieldset>

--- a/www/themes/Alpha/templates/partials/ads.tpl
+++ b/www/themes/Alpha/templates/partials/ads.tpl
@@ -1,16 +1,6 @@
 {if $ad != ''}
 	{if $type == 'base'}
 			{$ad}
-	{elseif $type == 'superrow'}
-
-				{include file='partials/_ad.tpl' ad=$ad}
-
-		<br>
-	{elseif $type == 'subrow'}
-
-				{include file='partials/_ad.tpl' ad=$ad}
-
-		<br>
 	{else}
 			{include file='partials/_ad.tpl' ad=$ad}
 		<br>

--- a/www/themes/Alpha/templates/partials/ads.tpl
+++ b/www/themes/Alpha/templates/partials/ads.tpl
@@ -1,0 +1,18 @@
+{if $ad != ''}
+	{if $type == 'base'}
+			{$ad}
+	{elseif $type == 'superrow'}
+
+				{include file='partials/_ad.tpl' ad=$ad}
+
+		<br>
+	{elseif $type == 'subrow'}
+
+				{include file='partials/_ad.tpl' ad=$ad}
+
+		<br>
+	{else}
+			{include file='partials/_ad.tpl' ad=$ad}
+		<br>
+	{/if}
+{/if}

--- a/www/themes/Alpha/templates/predb.tpl
+++ b/www/themes/Alpha/templates/predb.tpl
@@ -1,11 +1,4 @@
-{if {$site->adbrowse} != ''}
-	<div class="container" style="width:500px;">
-		<fieldset class="adbanner div-center">
-			<legend class="adbanner">Advertisement</legend>
-			{$site->adbrowse}
-		</fieldset></div>
-	<br>
-{/if}
+{include file='partials/ads.tpl' ad=$site->adbrowse}
 <h4>{$page->title}</h4>
 <form name="presearch" method="get" action="{$smarty.const.WWW_TOP}/predb" id="custom-search-form" class="form-search form-horizontal col-4 col-lg-4 pull-right">
 	<div id="search" class="input-group col-12 col-lg-12">

--- a/www/themes/Alpha/templates/search.tpl
+++ b/www/themes/Alpha/templates/search.tpl
@@ -1,12 +1,4 @@
-{if {$site->adbrowse} != ''}
-	<div class="container" style="width:500px;">
-		<fieldset class="adbanner div-center">
-			<legend class="adbanner">Advertisement</legend>
-			{$site->adbrowse}
-		</fieldset>
-	</div>
-	<br>
-{/if}
+{include file='partials/ads.tpl' ad=$site->adbrowse}
 <h3 class="text-center">
 	<a href="#" onclick="if (jQuery(this).text() == 'Advanced Search')
 		jQuery(this).text('Basic Search');

--- a/www/themes/Alpha/templates/upcoming.tpl
+++ b/www/themes/Alpha/templates/upcoming.tpl
@@ -1,14 +1,4 @@
-{if {$site->adbrowse} != ''}
-	<div class="row">
-		<div class="container" style="width:500px;">
-			<fieldset class="adbanner div-center">
-				<legend class="adbanner">Advertisement</legend>
-				{$site->adbrowse}
-			</fieldset>
-		</div>
-	</div>
-	<br>
-{/if}
+{include file='partials/ads.tpl' ad=$site->adbrowse}
 
 <p>
 	<a href="{$smarty.const.WWW_TOP}/upcoming/1">Box Office</a> |

--- a/www/themes/Alpha/templates/viewanimelist.tpl
+++ b/www/themes/Alpha/templates/viewanimelist.tpl
@@ -1,12 +1,4 @@
-{if {$site->adbrowse} != ''}
-	<div class="row">
-		<div class="container" style="width:500px;">
-			<fieldset class="adbanner div-center">
-				<legend class="adbanner">Advertisement</legend>
-				{$site->adbrowse}
-			</fieldset></div></div>
-	<br>
-{/if}
+{include file='partials/ads.tpl' ad=$site->adbrowse}
 <div>
 	<br>
 	<p style="font-size:16px">

--- a/www/themes/Alpha/templates/viewnzb.tpl
+++ b/www/themes/Alpha/templates/viewnzb.tpl
@@ -1,14 +1,4 @@
-{if {$site->addetail} != ''}
-	<div class="container" style="width:500px;">
-		<div class="row">
-			<fieldset class="adbanner div-center">
-				<legend class="adbanner">Advertisement</legend>
-				{$site->addetail}
-			</fieldset>
-		</div>
-	</div>
-	<br />
-{/if}
+{include file='partials/ads.tpl' ad=$site->addetail}
 
 <h2>{$release.searchname|escape:"htmlall"|truncate:100:"...":true}{if $failed != NULL && $failed > 0}<span class="btn btn-default btn-xs" title="This release has failed to download for some users">
 		<i class ="fa fa-thumbs-o-up"></i> {$release.grabs} Grab{if $release.grabs != 1}s{/if} / <i class ="fa fa-thumbs-o-down"></i> {$failed} Failed Download{if $failed != 1}s{/if}</span>{/if}</h2><br>

--- a/www/themes/Alpha/templates/viewserieslist.tpl
+++ b/www/themes/Alpha/templates/viewserieslist.tpl
@@ -1,14 +1,4 @@
-{if {$site->adbrowse} != ''}
-	<div class="row">
-		<div class="container" style="width:500px;">
-			<fieldset class="adbanner div-center">
-				<legend class="adbanner">Advertisement</legend>
-				{$site->adbrowse}
-			</fieldset>
-		</div>
-	</div>
-	<br>
-{/if}
+{include file='partials/ads.tpl' ad=$site->adbrowse}
 <div>
 	<br>
 	<p style="font-size:16px">

--- a/www/themes/Alpha/templates/xxx.tpl
+++ b/www/themes/Alpha/templates/xxx.tpl
@@ -1,12 +1,4 @@
-{if {$site->adbrowse} != ''}
-	<div class="container" style="width:500px;">
-		<fieldset class="adbanner div-center">
-			<legend class="adbanner">Advertisement</legend>
-			{$site->adbrowse}
-		</fieldset>
-	</div>
-	<br>
-{/if}
+{include file='partials/ads.tpl' ad=$site->adbrowse}
 <div class="panel">
 	<div class="panel-heading">
 		<h4 class="panel-title">


### PR DESCRIPTION
Unify ad output into a partial. This way you can have more control over the look and functionality of the ads. This PR is dependent on the container fix for bs3 PR. 