### PR TITLE
Disable API access for disabled users.

### DIFF
--- a/nzedb/utility/Misc.php
+++ b/nzedb/utility/Misc.php
@@ -685,4 +685,74 @@ class Misc
 
 		return $sent;
 	}
+
+	/**
+	 * Display error/error code.
+	 * @param int    $errorCode
+	 * @param string $errorText
+	 */
+	public static function showApiError($errorCode = 900, $errorText = '')
+	{
+		if ($errorText === '') {
+			switch ($errorCode) {
+				case 100:
+					$errorText = 'Incorrect user credentials';
+					break;
+				case 101:
+					$errorText = 'Account suspended';
+					break;
+				case 102:
+					$errorText = 'Insufficient privileges/not authorized';
+					break;
+				case 103:
+					$errorText = 'Registration denied';
+					break;
+				case 104:
+					$errorText = 'Registrations are closed';
+					break;
+				case 105:
+					$errorText = 'Invalid registration (Email Address Taken)';
+					break;
+				case 106:
+					$errorText = 'Invalid registration (Email Address Bad Format)';
+					break;
+				case 107:
+					$errorText = 'Registration Failed (Data error)';
+					break;
+				case 200:
+					$errorText = 'Missing parameter';
+					break;
+				case 201:
+					$errorText = 'Incorrect parameter';
+					break;
+				case 202:
+					$errorText = 'No such function';
+					break;
+				case 203:
+					$errorText = 'Function not available';
+					break;
+				case 300:
+					$errorText = 'No such item';
+					break;
+				case 500:
+					$errorText = 'Request limit reached';
+					break;
+				case 501:
+					$errorText = 'Download limit reached';
+					break;
+				default:
+					$errorText = 'Unknown error';
+					break;
+			}
+		}
+
+		$response =
+			"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" .
+			'<error code="' . $errorCode .  '" description="' . $errorText . "\"/>\n";
+		header('Content-type: text/xml');
+		header('Content-Length: ' . strlen($response) );
+		header('X-nZEDb: API ERROR [' . $errorCode . '] ' . $errorText);
+
+		exit($response);
+	}
 }

--- a/www/pages/api.php
+++ b/www/pages/api.php
@@ -45,10 +45,10 @@ if (isset($_GET['t'])) {
 			$function = 'r';
 			break;
 		default:
-			showApiError(202, 'No such function (' . $_GET['t'] . ')');
+			Misc::showApiError(202, 'No such function (' . $_GET['t'] . ')');
 	}
 } else {
-	showApiError(200, 'Missing parameter (t)');
+	Misc::showApiError(200, 'Missing parameter (t)');
 }
 
 $uid = $apiKey = '';
@@ -60,22 +60,28 @@ if ($page->users->isLoggedIn()) {
 	$apiKey = $page->userdata['rsstoken'];
 	$catExclusions = $page->userdata['categoryexclusions'];
 	$maxRequests = $page->userdata['apirequests'];
+	if ($page->users->isDisabled($page->userdata['username'])) {
+		Misc::showApiError(101, 'Insufficient privileges/not authorized (Free Account is Expired, Please Login to Webportal!)');
+	}
 } else {
 	if ($function != 'c' && $function != 'r') {
 		if (!isset($_GET['apikey'])) {
-			showApiError(200, 'Missing parameter (apikey)');
+			Misc::showApiError(200, 'Missing parameter (apikey)');
 		} else {
 			$res    = $page->users->getByRssToken($_GET['apikey']);
 			$apiKey = $_GET['apikey'];
 
 			if (!$res) {
-				showApiError(100, 'Incorrect user credentials (wrong API key)');
+				Misc::showApiError(100, 'Incorrect user credentials (wrong API key)');
 			}
 
-			$uid           = $res['id'];
-			$catExclusions = $page->users->getCategoryExclusion($uid);
-			$maxRequests   = $res['apirequests'];
+		if ($page->users->isDisabled($res['username'])) {
+			Misc::showApiError(101, 'Insufficient privileges/not authorized (Free Account is Expired, Please Login to Webportal!)');
 		}
+
+		$uid = $res['id'];
+		$catExclusions = $page->users->getCategoryExclusion($uid);
+		$maxRequests = $res['apirequests'];
 	}
 }
 
@@ -87,7 +93,7 @@ if ($uid != '') {
 	$page->users->updateApiAccessed($uid);
 	$apiRequests = $page->users->getApiRequests($uid);
 	if ($apiRequests > $maxRequests) {
-		showApiError(500, 'Request limit reached (' . $apiRequests . '/' . $maxRequests . ')');
+		Misc::showApiError(500, 'Request limit reached (' . $apiRequests . '/' . $maxRequests . ')');
 	}
 }
 
@@ -205,7 +211,7 @@ switch ($function) {
 	// Get NZB.
 	case 'g':
 		if (!isset($_GET['id'])) {
-			showApiError(200, 'Missing parameter (id is required for downloading an NZB)');
+			Misc::showApiError(200, 'Missing parameter (id is required for downloading an NZB)');
 		}
 
 		$relData = $releases->getByGuid($_GET['id']);
@@ -222,14 +228,14 @@ switch ($function) {
 				((isset($_GET['del']) && $_GET['del'] == '1') ? '&del=1' : '')
 			);
 		} else {
-			showApiError(300, 'No such item (the guid you provided has no release in our database)');
+			Misc::showApiError(300, 'No such item (the guid you provided has no release in our database)');
 		}
 		break;
 
 	// Get individual NZB details.
 	case 'd':
 		if (!isset($_GET['id'])) {
-			showApiError(200, 'Missing parameter (id is required for downloading an NZB)');
+			Misc::showApiError(200, 'Missing parameter (id is required for downloading an NZB)');
 		}
 
 		$page->users->addApiRequest($uid, $_SERVER['REQUEST_URI']);
@@ -246,7 +252,7 @@ switch ($function) {
 	// Get an NFO file for an individual release.
 	case 'n':
 		if (!isset($_GET['id'])) {
-			showApiError(200, 'Missing parameter (id is required for retrieving an NFO)');
+			Misc::showApiError(200, 'Missing parameter (id is required for retrieving an NFO)');
 		}
 
 		$page->users->addApiRequest($uid, $_SERVER['REQUEST_URI']);
@@ -263,10 +269,10 @@ switch ($function) {
 					echo nl2br(Text::cp437toUTF($data['nfo']));
 				}
 			} else {
-				showApiError(300, 'Release does not have an NFO file associated.');
+				Misc::showApiError(300, 'Release does not have an NFO file associated.');
 			}
 		} else {
-			showApiError(300, 'Release does not exist.');
+			Misc::showApiError(300, 'Release does not exist.');
 		}
 
 		break;
@@ -343,74 +349,7 @@ switch ($function) {
 		break;
 }
 
-/**
- * Display error/error code.
- * @param int    $errorCode
- * @param string $errorText
- */
-function showApiError($errorCode = 900, $errorText = '')
-{
-	if ($errorText === '') {
-		switch ($errorCode) {
-			case 100:
-				$errorText = 'Incorrect user credentials';
-				break;
-			case 101:
-				$errorText = 'Account suspended';
-				break;
-			case 102:
-				$errorText = 'Insufficient privileges/not authorized';
-				break;
-			case 103:
-				$errorText = 'Registration denied';
-				break;
-			case 104:
-				$errorText = 'Registrations are closed';
-				break;
-			case 105:
-				$errorText = 'Invalid registration (Email Address Taken)';
-				break;
-			case 106:
-				$errorText = 'Invalid registration (Email Address Bad Format)';
-				break;
-			case 107:
-				$errorText = 'Registration Failed (Data error)';
-				break;
-			case 200:
-				$errorText = 'Missing parameter';
-				break;
-			case 201:
-				$errorText = 'Incorrect parameter';
-				break;
-			case 202:
-				$errorText = 'No such function';
-				break;
-			case 203:
-				$errorText = 'Function not available';
-				break;
-			case 300:
-				$errorText = 'No such item';
-				break;
-			case 500:
-				$errorText = 'Request limit reached';
-				break;
-			case 501:
-				$errorText = 'Download limit reached';
-				break;
-			default:
-				$errorText = 'Unknown error';
-				break;
-		}
-	}
 
-	$response =
-		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" .
-		'<error code="' . $errorCode .  '" description="' . $errorText . "\"/>\n";
-	header('Content-type: text/xml');
-	header('Content-Length: ' . strlen($response) );
-	header('X-nZEDb: API ERROR [' . $errorCode . '] ' . $errorText);
-
-	exit($response);
 }
 
 /**
@@ -422,9 +361,9 @@ function maxAge()
 	$maxAge = -1;
 	if (isset($_GET['maxage'])) {
 		if ($_GET['maxage'] == '') {
-			showApiError(201, 'Incorrect parameter (maxage must not be empty)');
+			Misc::showApiError(201, 'Incorrect parameter (maxage must not be empty)');
 		} elseif (!is_numeric($_GET['maxage'])) {
-			showApiError(201, 'Incorrect parameter (maxage must be numeric)');
+			Misc::showApiError(201, 'Incorrect parameter (maxage must be numeric)');
 		} else {
 			$maxAge = (int)$_GET['maxage'];
 		}
@@ -508,7 +447,7 @@ function printOutput($data, $xml = true, $page, $offset = 0)
 function verifyEmptyParameter($parameter)
 {
 	if (isset($_GET[$parameter]) && $_GET[$parameter] == '') {
-		showApiError(201, 'Incorrect parameter (' . $parameter . ' must not be empty)');
+		Misc::showApiError(201, 'Incorrect parameter (' . $parameter . ' must not be empty)');
 	}
 }
 
@@ -551,7 +490,7 @@ function encodeAsJSON($data)
 {
 	$json = json_encode(Text::encodeAsUTF8($data));
 	if ($json === false) {
-		showApiError(201);
+		Misc::showApiError(201);
 	}
 	return $json;
 }

--- a/www/pages/api.php
+++ b/www/pages/api.php
@@ -61,7 +61,7 @@ if ($page->users->isLoggedIn()) {
 	$catExclusions = $page->userdata['categoryexclusions'];
 	$maxRequests = $page->userdata['apirequests'];
 	if ($page->users->isDisabled($page->userdata['username'])) {
-		Misc::showApiError(101, 'Insufficient privileges/not authorized (Free Account is Expired, Please Login to Webportal!)');
+		Misc::showApiError(101);
 	}
 } else {
 	if ($function != 'c' && $function != 'r') {
@@ -76,7 +76,7 @@ if ($page->users->isLoggedIn()) {
 			}
 
 		if ($page->users->isDisabled($res['username'])) {
-			Misc::showApiError(101, 'Insufficient privileges/not authorized (Free Account is Expired, Please Login to Webportal!)');
+			Misc::showApiError(101);
 		}
 
 		$uid = $res['id'];

--- a/www/pages/getnzb.php
+++ b/www/pages/getnzb.php
@@ -13,7 +13,7 @@ if ($page->users->isLoggedIn()) {
 	$maxDownloads = $page->userdata["downloadrequests"];
 	$rssToken = $page->userdata['rsstoken'];
 	if ($page->users->isDisabled($page->userdata['username'])) {
-		Misc::showApiError(101, 'Insufficient privileges/not authorized (Free Account is Expired, Please Login to Webportal!)');
+		Misc::showApiError(101);
 	}
 } else {
 	if ($page->settings->getSetting('registerstatus') == Settings::REGISTER_STATUS_API_ONLY) {
@@ -36,7 +36,7 @@ if ($page->users->isLoggedIn()) {
 	$rssToken = $res['rsstoken'];
 	$maxDownloads = $res["downloadrequests"];
 	if ($page->users->isDisabled($res['username'])) {
-		Misc::showApiError(101, 'Insufficient privileges/not authorized (Free Account is Expired, Please Login to Webportal!)');
+		Misc::showApiError(101);
 	}
 }
 

--- a/www/pages/getnzb.php
+++ b/www/pages/getnzb.php
@@ -2,6 +2,7 @@
 
 use nzedb\Releases;
 use nzedb\NZB;
+use nzedb\utility\Misc;
 $uid = 0;
 
 use nzedb\db\Settings;
@@ -11,6 +12,9 @@ if ($page->users->isLoggedIn()) {
 	$uid = $page->users->currentUserId();
 	$maxDownloads = $page->userdata["downloadrequests"];
 	$rssToken = $page->userdata['rsstoken'];
+	if ($page->users->isDisabled($page->userdata['username'])) {
+		Misc::showApiError(101, 'Insufficient privileges/not authorized (Free Account is Expired, Please Login to Webportal!)');
+	}
 } else {
 	if ($page->settings->getSetting('registerstatus') == Settings::REGISTER_STATUS_API_ONLY) {
 		$res = $page->users->getById(0);
@@ -31,6 +35,9 @@ if ($page->users->isLoggedIn()) {
 	$uid = $res["id"];
 	$rssToken = $res['rsstoken'];
 	$maxDownloads = $res["downloadrequests"];
+	if ($page->users->isDisabled($res['username'])) {
+		Misc::showApiError(101, 'Insufficient privileges/not authorized (Free Account is Expired, Please Login to Webportal!)');
+	}
 }
 
 // Check download limit on user role.

--- a/www/pages/rss.php
+++ b/www/pages/rss.php
@@ -75,7 +75,7 @@ if (!isset($_GET["t"]) && !isset($_GET["show"]) && !isset($_GET["anidb"])) {
 		$username = $res['username'];
 
 		if ($page->users->isDisabled($username)) {
-			Misc::showApiError(101,'Insufficient privileges/not authorized (Free Account is Expired, Please Login to Webportal!)');
+			Misc::showApiError(101);
 		}
 	}
 

--- a/www/pages/rss.php
+++ b/www/pages/rss.php
@@ -3,6 +3,7 @@
 use nzedb\Category;
 use nzedb\RSS;
 use nzedb\db\Settings;
+use nzedb\utility\Misc;
 
 $category = new Category(['Settings' => $page->settings]);
 $rss = new RSS(['Settings' => $page->settings]);
@@ -12,8 +13,7 @@ if (!isset($_GET["t"]) && !isset($_GET["show"]) && !isset($_GET["anidb"])) {
 	// User has to either be logged in, or using rsskey.
 	if (!$page->users->isLoggedIn()) {
 		if ($page->settings->getSetting('registerstatus') != Settings::REGISTER_STATUS_API_ONLY) {
-			header('X-nZEDb: ERROR: You must be logged in or provide a valid User ID and API key!');
-			$page->show403();
+			Misc::showApiError(100);
 		} else {
 			header("Location: " . $page->settings->getSetting('code'));
 		}
@@ -59,26 +59,28 @@ if (!isset($_GET["t"]) && !isset($_GET["show"]) && !isset($_GET["anidb"])) {
 			$res = $page->users->getById(0);
 		} else {
 			if (!isset($_GET["i"]) || !isset($_GET["r"])) {
-				header('X-nZEDb: ERROR: Both the User ID and API key are required for viewing the RSS!');
-				$page->show403();
+				Misc::showApiError(100, 'Both the User ID and API key are required for viewing the RSS!');
 			}
 
 			$res = $page->users->getByIdAndRssToken($_GET["i"], $_GET["r"]);
 		}
 
 		if (!$res) {
-			header('X-nZEDb: ERROR: Invalid API key or User ID!');
-			$page->show403();
+			Misc::showApiError(100);
 		}
 
 		$uid = $res["id"];
 		$rssToken = $res['rsstoken'];
 		$maxRequests = $res['apirequests'];
+		$username = $res['username'];
+
+		if ($page->users->isDisabled($username)) {
+			Misc::showApiError(101,'Insufficient privileges/not authorized (Free Account is Expired, Please Login to Webportal!)');
+		}
 	}
 
 	if ($page->users->getApiRequests($uid) > $maxRequests) {
-		header('X-nZEDb: ERROR: You have reached your daily limit for API requests!');
-		$page->show503();
+		Misc::showApiError(500, 'You have reached your daily limit for API requests!');
 	} else {
 		$page->users->addApiRequest($uid, $_SERVER['REQUEST_URI']);
 	}


### PR DESCRIPTION
If a user has the role of "disabled" they should not be able to download NZB's, pull RSS feeds, or query the API. This PR adds checks for this.

In addition, the showApiError function has been moved to the Misc class for easy access and the error display in the pages/rss.php have been unified with the other api endpoints. 