### PR TITLE
Add a trailing slash to sab url if one does not exist.

### DIFF
--- a/nzedb/SABnzbd.php
+++ b/nzedb/SABnzbd.php
@@ -139,6 +139,8 @@ class SABnzbd
 				}
 				break;
 		}
+		if (substr($this->url, -1) != '/')
+			$this->url .= '/';
 	}
 
 	/**


### PR DESCRIPTION
Further functions expect a trailing slash and one is not enforced in profileedit. I considered enforcing it there but then I'd have to write a script to update everyones sab url info in the database (or use this code as well), this way I achieve the necessary tweak with 2 lines of code total.
