### PR TITLE
New release name format not matched with reqid

### DIFF
--- a/nzedb/RequestID.php
+++ b/nzedb/RequestID.php
@@ -229,7 +229,7 @@ abstract class RequestID
 							$requestID):
 			case preg_match('/\[\s*(\d+)\s*\]/', $this->_release['name'], $requestID):
 			case preg_match('/^REQ\s*(\d{4,6})/i', $this->_release['name'], $requestID):
-			case preg_match('/^(\d{4,6})-\d{1}\[/', $this->_release['name'], $requestID):
+			case preg_match('/^(\d{4,6})-\d{1}\s?\[/', $this->_release['name'], $requestID):
 			case preg_match('/(\d{4,6}) -/', $this->_release['name'], $requestID):
 				if ((int)$requestID[1] > 0) {
 					return (int)$requestID[1];


### PR DESCRIPTION
Addresses issue #.
## Changes made by this pull request.
## 
## 

Used to be XXXXX-X[XX/XX] - "XXXXX-X.par2" yEnc, now comes in XXXXX-X [XX/XX] - "XXXXX-X.par2"
