### PR TITLE
Add leftguid column to releases to improve threading work queries

### DIFF
--- a/misc/update/nix/tmux/bin/groupfixrelnames.php
+++ b/misc/update/nix/tmux/bin/groupfixrelnames.php
@@ -23,21 +23,21 @@ if (!isset($argv[1])) {
 	switch (true) {
 		case $pieces[0] === 'nfo' && isset($guidChar) && isset($maxperrun) && is_numeric($maxperrun):
 			$releases = $pdo->queryDirect(
-							sprintf('
-								SELECT r.id AS releases_id, r.guid, r.group_id, r.categories_id, r.name, r.searchname,
-									uncompress(nfo) AS textstring
-								FROM releases r
-								INNER JOIN release_nfos rn ON r.id = rn.releases_id
-								WHERE r.guid %s
-								AND r.nzbstatus = 1
-								AND r.proc_nfo = 0
-								AND r.nfostatus = 1
-								AND r.predb_id = 0
-								ORDER BY r.postdate DESC
-								LIMIT %s',
-								$pdo->likeString($guidChar, false, true),
-								$maxperrun
-							)
+				sprintf('
+					SELECT r.id AS releases_id, r.guid, r.group_id, r.categories_id, r.name, r.searchname,
+						uncompress(nfo) AS textstring
+					FROM releases r
+					INNER JOIN release_nfos rn ON r.id = rn.releases_id
+					WHERE r.leftguid = %s
+					AND r.nzbstatus = 1
+					AND r.proc_nfo = 0
+					AND r.nfostatus = 1
+					AND r.predb_id = 0
+					ORDER BY r.postdate DESC
+					LIMIT %s',
+					$pdo->escapeString($guidChar),
+					$maxperrun
+				)
 			);
 
 			if ($releases instanceof \Traversable) {
@@ -59,19 +59,19 @@ if (!isset($argv[1])) {
 			break;
 		case $pieces[0] === 'filename' && isset($guidChar) && isset($maxperrun) && is_numeric($maxperrun):
 			$releases = $pdo->queryDirect(
-							sprintf('
-								SELECT rf.name AS textstring, rf.releases_id AS fileid,
-									r.id AS releases_id, r.name, r.searchname, r.categories_id, r.group_id
-								FROM releases r
-								INNER JOIN release_files rf ON r.id = rf.releases_id
-								WHERE r.guid %s
-								AND r.nzbstatus = 1 AND r.proc_files = 0
-								AND r.predb_id = 0
-								ORDER BY r.postdate ASC
-								LIMIT %s',
-								$pdo->likeString($guidChar, false, true),
-								$maxperrun
-							)
+				sprintf('
+					SELECT rf.name AS textstring, rf.releases_id AS fileid,
+						r.id AS releases_id, r.name, r.searchname, r.categories_id, r.group_id
+					FROM releases r
+					INNER JOIN release_files rf ON r.id = rf.releases_id
+					WHERE r.leftguid = %s
+					AND r.nzbstatus = 1 AND r.proc_files = 0
+					AND r.predb_id = 0
+					ORDER BY r.postdate ASC
+					LIMIT %s',
+					$pdo->escapeString($guidChar),
+					$maxperrun
+				)
 			);
 
 			if ($releases instanceof \Traversable) {
@@ -86,20 +86,20 @@ if (!isset($argv[1])) {
 			break;
 		case $pieces[0] === 'md5' && isset($guidChar) && isset($maxperrun) && is_numeric($maxperrun):
 			$releases = $pdo->queryDirect(
-							sprintf('
-								SELECT DISTINCT r.id AS releases_id, r.name, r.searchname, r.categories_id, r.group_id, r.dehashstatus,
-									rf.name AS filename
-								FROM releases r
-								LEFT OUTER JOIN release_files rf ON r.id = rf.releases_id AND rf.ishashed = 1
-								WHERE r.guid %s
-								AND nzbstatus = 1 AND r.ishashed = 1
-								AND r.dehashstatus BETWEEN -6 AND 0
-								AND r.predb_id = 0
-								ORDER BY r.dehashstatus DESC, r.postdate ASC
-								LIMIT %s',
-								$pdo->likeString($guidChar, false, true),
-								$maxperrun
-							)
+				sprintf('
+					SELECT DISTINCT r.id AS releases_id, r.name, r.searchname, r.categories_id, r.group_id, r.dehashstatus,
+						rf.name AS filename
+					FROM releases r
+					LEFT OUTER JOIN release_files rf ON r.id = rf.releases_id AND rf.ishashed = 1
+					WHERE r.leftguid = %s
+					AND nzbstatus = 1 AND r.ishashed = 1
+					AND r.dehashstatus BETWEEN -6 AND 0
+					AND r.predb_id = 0
+					ORDER BY r.dehashstatus DESC, r.postdate ASC
+					LIMIT %s',
+					$pdo->escapeString($guidChar),
+					$maxperrun
+				)
 			);
 
 			if ($releases instanceof \Traversable) {
@@ -117,18 +117,18 @@ if (!isset($argv[1])) {
 			break;
 		case $pieces[0] === 'par2' && isset($guidChar) && isset($maxperrun) && is_numeric($maxperrun):
 			$releases = $pdo->queryDirect(
-							sprintf('
-								SELECT r.id AS releases_id, r.guid, r.group_id
-								FROM releases r
-								WHERE r.guid %s
-								AND r.nzbstatus = 1
-								AND r.proc_par2 = 0
-								AND r.predb_id = 0
-								ORDER BY r.postdate ASC
-								LIMIT %s',
-								$pdo->likeString($guidChar, false, true),
-								$maxperrun
-							)
+				sprintf('
+					SELECT r.id AS releases_id, r.guid, r.group_id
+					FROM releases r
+					WHERE r.leftguid = %s
+					AND r.nzbstatus = 1
+					AND r.proc_par2 = 0
+					AND r.predb_id = 0
+					ORDER BY r.postdate ASC
+					LIMIT %s',
+					$pdo->escapeString($guidChar),
+					$maxperrun
+				)
 			);
 
 			if ($releases instanceof \Traversable) {
@@ -154,18 +154,18 @@ if (!isset($argv[1])) {
 			break;
 		case $pieces[0] === 'miscsorter' && isset($guidChar) && isset($maxperrun) && is_numeric($maxperrun):
 			$releases = $pdo->queryDirect(
-							sprintf('
-								SELECT r.id AS releases_id
-								FROM releases r
-								WHERE r.guid %s
-								AND r.nzbstatus = 1 AND r.nfostatus = 1
-								AND r.proc_sorter = 0 AND r.isrenamed = 0
-								AND r.predb_id = 0
-								ORDER BY r.postdate DESC
-								LIMIT %s',
-								$pdo->likeString($guidChar, false, true),
-								$maxperrun
-							)
+				sprintf('
+					SELECT r.id AS releases_id
+					FROM releases r
+					WHERE r.leftguid = %s
+					AND r.nzbstatus = 1 AND r.nfostatus = 1
+					AND r.proc_sorter = 0 AND r.isrenamed = 0
+					AND r.predb_id = 0
+					ORDER BY r.postdate DESC
+					LIMIT %s',
+					$pdo->escapeString($guidChar),
+					$maxperrun
+				)
 			);
 
 			if ($releases instanceof \Traversable) {

--- a/misc/update/python/groupfixrelnames_threaded.py
+++ b/misc/update/python/groupfixrelnames_threaded.py
@@ -41,7 +41,7 @@ groupby = "GROUP BY guidchar"
 orderby = "ORDER BY guidchar ASC"
 rowlimit = "LIMIT 16"
 extrawhere = "AND r.preid = 0 AND r.nzbstatus = 1"
-select = "DISTINCT LEFT(r.guid, 1) AS guidchar, COUNT(*) AS count"
+select = "r.leftguid AS guidchar, COUNT(*) AS count"
 
 cur[0].execute("SELECT value FROM settings WHERE setting = 'fixnamethreads'")
 run_threads = cur[0].fetchone()

--- a/misc/update/python/postprocess_threaded.py
+++ b/misc/update/python/postprocess_threaded.py
@@ -130,22 +130,22 @@ process_additional = run_threads * ppperrun
 process_nfo = run_threads * nfoperrun
 
 if sys.argv[1] == "additional":
-	cur[0].execute("SELECT LEFT(r.guid, 1) FROM releases r LEFT JOIN category c ON c.id = r.categoryid WHERE r.nzbstatus = 1 "+maxsize+" AND (r.haspreview = -1 AND c.disablepreview = 0) AND r.passwordstatus BETWEEN -6 AND -1 GROUP BY LEFT(r.guid, 1) LIMIT 16")
+	cur[0].execute("SELECT leftguid FROM releases r LEFT JOIN category c ON c.id = r.categoryid WHERE r.nzbstatus = 1 "+maxsize+" AND (r.haspreview = -1 AND c.disablepreview = 0) AND r.passwordstatus BETWEEN -6 AND -1 GROUP BY leftguid LIMIT 16")
 	datas = cur[0].fetchall()
 elif sys.argv[1] == "nfo":
-	cur[0].execute("SELECT LEFT(guid, 1) FROM releases WHERE nzbstatus = 1 AND nfostatus BETWEEN -8 AND -1 GROUP BY LEFT(guid, 1) LIMIT 16")
+	cur[0].execute("SELECT leftguid FROM releases WHERE nzbstatus = 1 AND nfostatus BETWEEN -8 AND -1 GROUP BY leftguid LIMIT 16")
 	datas = cur[0].fetchall()
 elif sys.argv[1] == "movie" and len(sys.argv) == 3 and sys.argv[2] == "clean":
-	cur[0].execute("SELECT LEFT(guid, 1) FROM releases WHERE nzbstatus = 1 AND isrenamed = 1 AND searchname IS NOT NULL AND imdbid IS NULL AND categoryid BETWEEN 2000 AND 2999 GROUP BY LEFT(guid, 1) "+orderBY+" LIMIT 16")
+	cur[0].execute("SELECT leftguid FROM releases WHERE nzbstatus = 1 AND isrenamed = 1 AND searchname IS NOT NULL AND imdbid IS NULL AND categoryid BETWEEN 2000 AND 2999 GROUP BY leftguid "+orderBY+" LIMIT 16")
 	datas = cur[0].fetchall()
 elif sys.argv[1] == "movie":
-	cur[0].execute("SELECT LEFT(guid, 1) FROM releases WHERE nzbstatus = 1 AND searchname IS NOT NULL AND imdbid IS NULL AND categoryid BETWEEN 2000 AND 2999 GROUP BY LEFT(guid, 1) "+orderBY+" LIMIT 16")
+	cur[0].execute("SELECT leftguid FROM releases WHERE nzbstatus = 1 AND searchname IS NOT NULL AND imdbid IS NULL AND categoryid BETWEEN 2000 AND 2999 GROUP BY leftguid "+orderBY+" LIMIT 16")
 	datas = cur[0].fetchall()
 elif sys.argv[1] == "tv" and len(sys.argv) == 3 and sys.argv[2] == "clean":
-	cur[0].execute("SELECT LEFT(guid, 1) FROM releases WHERE nzbstatus = 1 AND isrenamed = 1 AND searchname IS NOT NULL AND videos_id = 0 AND categoryid BETWEEN 5000 AND 5999 GROUP BY LEFT(guid, 1) "+orderBY+" LIMIT 16")
+	cur[0].execute("SELECT leftguid FROM releases WHERE nzbstatus = 1 AND isrenamed = 1 AND searchname IS NOT NULL AND videos_id = 0 AND categoryid BETWEEN 5000 AND 5999 GROUP BY leftguid "+orderBY+" LIMIT 16")
 	datas = cur[0].fetchall()
 elif sys.argv[1] == "tv":
-	cur[0].execute("SELECT LEFT(guid, 1) FROM releases WHERE nzbstatus = 1 AND searchname IS NOT NULL AND videos_id = 0 AND categoryid BETWEEN 5000 AND 5999 GROUP BY LEFT(guid, 1) "+orderBY+" LIMIT 16")
+	cur[0].execute("SELECT leftguid FROM releases WHERE nzbstatus = 1 AND searchname IS NOT NULL AND videos_id = 0 AND categoryid BETWEEN 5000 AND 5999 GROUP BY leftguid "+orderBY+" LIMIT 16")
 	datas = cur[0].fetchall()
 
 #close connection to mysql

--- a/nzedb/Movie.php
+++ b/nzedb/Movie.php
@@ -1075,19 +1075,19 @@ class Movie
 
 		// Get all releases without an IMDB id.
 		$res = $this->pdo->query(
-				sprintf("
-				SELECT r.searchname, r.id
-				FROM releases r
-				WHERE r.imdbid IS NULL
-				AND r.nzbstatus = 1
-				%s %s %s %s
-				LIMIT %d",
-				$this->catWhere,
-				($groupID === '' ? '' : ('AND r.group_id = ' . $groupID)),
-				($guidChar === '' ? '' : ('AND r.guid ' . $this->pdo->likeString($guidChar, false, true))),
-				($lookupIMDB == 2 ? 'AND r.isrenamed = 1' : ''),
-				$this->movieqty
-				)
+			sprintf("
+			SELECT r.searchname, r.id
+			FROM releases r
+			WHERE r.imdbid IS NULL
+			AND r.nzbstatus = 1
+			%s %s %s %s
+			LIMIT %d",
+			$this->catWhere,
+			($groupID === '' ? '' : ('AND r.group_id = ' . $groupID)),
+			($guidChar === '' ? '' : 'AND r.leftguid = ' . $this->pdo->escapeString($guidChar)),
+			($lookupIMDB == 2 ? 'AND r.isrenamed = 1' : ''),
+			$this->movieqty
+			)
 		);
 		$movieCount = count($res);
 

--- a/nzedb/Nfo.php
+++ b/nzedb/Nfo.php
@@ -294,7 +294,7 @@ class Nfo
 	public function processNfoFiles($nntp, $groupID = '', $guidChar = '', $processImdb = 1, $processTv = 1)
 	{
 		$ret = 0;
-		$guidCharQuery = ($guidChar === '' ? '' : 'AND r.guid ' . $this->pdo->likeString($guidChar, false, true));
+		$guidCharQuery = ($guidChar === '' ? '' : 'AND r.leftguid = ' . $this->pdo->escapeString($guidChar));
 		$groupIDQuery = ($groupID === '' ? '' : 'AND r.group_id = ' . $groupID);
 		$optionsQuery = self::NfoQueryString($this->pdo);
 

--- a/nzedb/Releases.php
+++ b/nzedb/Releases.php
@@ -75,16 +75,17 @@ class Releases
 	public function insertRelease(array $parameters = [])
 	{
 		$parameters['id'] = $this->pdo->queryInsert(
-			sprintf(
-				"INSERT INTO releases
-					(name, searchname, totalpart, group_id, adddate, guid, postdate, fromname,
+			sprintf("
+				INSERT INTO releases
+					(name, searchname, totalpart, group_id, adddate, guid, leftguid, postdate, fromname,
 					size, passwordstatus, haspreview, categories_id, nfostatus, nzbstatus,
 					isrenamed, iscategorized, reqidstatus, predb_id)
-				 VALUES (%s, %s, %d, %d, NOW(), %s, %s, %s, %s, %d, -1, %d, -1, %d, %d, 1, %d, %d)",
+				VALUES (%s, %s, %d, %d, NOW(), %s, LEFT(%s, 1), %s, %s, %s, %d, -1, %d, -1, %d, %d, 1, %d, %d)",
 				$parameters['name'],
 				$parameters['searchname'],
 				$parameters['totalpart'],
 				$parameters['group_id'],
+				$parameters['guid'],
 				$parameters['guid'],
 				$parameters['postdate'],
 				$parameters['fromname'],

--- a/nzedb/RequestIDLocal.php
+++ b/nzedb/RequestIDLocal.php
@@ -31,7 +31,7 @@ class RequestIDLocal extends RequestID
 			AND r.isrequestid = 1'
 		);
 
-		$query .= ($this->_charGUID === '' ? '' : ' AND r.guid ' . $this->pdo->likeString($this->_charGUID, false, true));
+		$query .= ($this->_charGUID === '' ? '' : ' AND r.leftguid = ' . $this->pdo->escapeString($this->_charGUID));
 		$query .= ($this->_groupID === '' ? '' : ' AND r.group_id = ' . $this->_groupID);
 		$query .= ($this->_maxTime === 0 ? '' : sprintf(' AND r.adddate > NOW() - INTERVAL %d HOUR', $this->_maxTime));
 

--- a/nzedb/libraries/Forking.php
+++ b/nzedb/libraries/Forking.php
@@ -428,7 +428,13 @@ class Forking extends \fork_daemon
 		$maxmssgs = $this->pdo->getSetting('maxmssgs');
 		$threads = $this->pdo->getSetting('binarythreads');
 
-		$groups = $this->pdo->query("SELECT g.name AS groupname, g.last_record AS our_last, a.last_record AS their_last FROM groups g INNER JOIN short_groups a ON g.active = 1 AND g.name = a.name ORDER BY a.last_record DESC");
+		$groups = $this->pdo->query("
+			SELECT g.name AS groupname, g.last_record AS our_last,
+				a.last_record AS their_last
+			FROM groups g
+			INNER JOIN short_groups a ON g.active = 1 AND g.name = a.name
+			ORDER BY a.last_record DESC"
+		);
 
 		if ($groups) {
 			$i = 1;
@@ -491,7 +497,7 @@ class Forking extends \fork_daemon
 		$orderby = "ORDER BY guidchar ASC";
 		$rowLimit = "LIMIT 16";
 		$extrawhere = "AND r.predb_id = 0 AND r.nzbstatus = 1";
-		$select = "DISTINCT r.leftguid AS guidchar, COUNT(r.id) AS count";
+		$select = "r.leftguid AS guidchar, COUNT(r.id) AS count";
 
 		$threads = $this->pdo->getSetting('fixnamethreads');
 		$maxperrun = $this->pdo->getSetting('fixnamesperrun');
@@ -529,7 +535,20 @@ class Forking extends \fork_daemon
 				break;
 		}
 
-		$datas = $this->pdo->query(sprintf("SELECT %s FROM releases r %s WHERE %s %s %s %s %s", $select, $join, $where, $extrawhere, $groupby, $orderby, $rowLimit));
+		$datas = $this->pdo->query(
+			sprintf("
+				SELECT %s
+				FROM releases r %s
+				WHERE %s %s %s %s %s",
+				$select,
+				$join,
+				$where,
+				$extrawhere,
+				$groupby,
+				$orderby,
+				$rowLimit
+			)
+		);
 
 		if ($datas) {
 			$count = 0;
@@ -758,7 +777,6 @@ class Forking extends \fork_daemon
 						AND categories_id BETWEEN %d AND %d
 						%s %s
 						LIMIT 1',
-
 						NZB::NZB_ADDED,
 						Category::MOVIE_ROOT,
 						Category::MOVIE_OTHER,
@@ -779,13 +797,13 @@ class Forking extends \fork_daemon
 			$this->register_child_run([0 => $this, 1 => 'postProcessChildWorker']);
 			$this->work = $this->pdo->query(
 				sprintf('
-					SELECT LEFT(guid, 1) AS id, %d AS renamed
+					SELECT leftguid AS id, %d AS renamed
 					FROM releases
 					WHERE nzbstatus = %d
 					AND imdbid IS NULL
 					AND categories_id BETWEEN ' . Category::MOVIE_ROOT . ' AND ' . Category::MOVIE_OTHER . '
 					%s %s
-					GROUP BY LEFT(guid, 1)
+					GROUP BY leftguid
 					LIMIT 16',
 					($this->ppRenamedOnly ? 2 : 1),
 					NZB::NZB_ADDED,
@@ -816,7 +834,6 @@ class Forking extends \fork_daemon
 						AND categories_id BETWEEN %d AND %d
 						%s %s
 						LIMIT 1',
-
 						NZB::NZB_ADDED,
 						Category::TV_ROOT,
 						Category::TV_OTHER,
@@ -837,16 +854,15 @@ class Forking extends \fork_daemon
 			$this->register_child_run([0 => $this, 1 => 'postProcessChildWorker']);
 			$this->work = $this->pdo->query(
 				sprintf('
-					SELECT LEFT(guid, 1) AS id, %d AS renamed
+					SELECT leftguid AS id, %d AS renamed
 					FROM releases
 					WHERE nzbstatus = %d
 					AND tv_episodes_id BETWEEN -2 AND 0
 					AND size > 1048576
 					AND categories_id BETWEEN %d AND %d
 					%s %s
-					GROUP BY LEFT(guid, 1)
+					GROUP BY leftguid
 					LIMIT 16',
-
 					($this->ppRenamedOnly ? 2 : 1),
 					NZB::NZB_ADDED,
 					Category::TV_ROOT,

--- a/nzedb/libraries/Forking.php
+++ b/nzedb/libraries/Forking.php
@@ -491,7 +491,7 @@ class Forking extends \fork_daemon
 		$orderby = "ORDER BY guidchar ASC";
 		$rowLimit = "LIMIT 16";
 		$extrawhere = "AND r.predb_id = 0 AND r.nzbstatus = 1";
-		$select = "DISTINCT LEFT(r.guid, 1) AS guidchar, COUNT(r.id) AS count";
+		$select = "DISTINCT r.leftguid AS guidchar, COUNT(r.id) AS count";
 
 		$threads = $this->pdo->getSetting('fixnamethreads');
 		$maxperrun = $this->pdo->getSetting('fixnamesperrun');
@@ -678,7 +678,7 @@ class Forking extends \fork_daemon
 			$this->register_child_run([0 => $this, 1 => 'postProcessChildWorker']);
 			$this->work = $this->pdo->query(
 				sprintf('
-					SELECT LEFT(r.guid, 1) AS id
+					SELECT leftguid AS id
 					FROM releases r
 					LEFT JOIN categories c ON c.id = r.categories_id
 					WHERE r.nzbstatus = %d
@@ -686,7 +686,7 @@ class Forking extends \fork_daemon
 					AND r.haspreview = -1
 					AND c.disablepreview = 0
 					%s %s
-					GROUP BY LEFT(r.guid, 1)
+					GROUP BY leftguid
 					LIMIT 16',
 					NZB::NZB_ADDED,
 					$this->ppAddMaxSize,
@@ -728,10 +728,10 @@ class Forking extends \fork_daemon
 			$this->register_child_run([0 => $this, 1 => 'postProcessChildWorker']);
 			$this->work = $this->pdo->query(
 				sprintf('
-					SELECT LEFT(r.guid, 1) AS id
+					SELECT leftguid AS id
 					FROM releases r
 					WHERE 1=1 %s
-					GROUP BY LEFT(r.guid, 1)
+					GROUP BY leftguid
 					LIMIT 16',
 					$this->nfoQueryString
 				)

--- a/nzedb/processing/post/ProcessAdditional.php
+++ b/nzedb/processing/post/ProcessAdditional.php
@@ -628,7 +628,7 @@ class ProcessAdditional
 				$this->_maxSize,
 				$this->_minSize,
 				($groupID === '' ? '' : 'AND r.group_id = ' . $groupID),
-				($guidChar === '' ? '' : 'AND r.guid ' . $this->pdo->likeString($guidChar, false, true)),
+				($guidChar === '' ? '' : 'AND r.leftguid = ' . $this->pdo->escapeString($guidChar)),
 				$this->_queryLimit
 			)
 		);

--- a/nzedb/processing/tv/TV.php
+++ b/nzedb/processing/tv/TV.php
@@ -50,6 +50,11 @@ abstract class TV extends Videos
 	public $siteColumns;
 
 	/**
+	 * @var string The TV categories_id lookup SQL language
+	 */
+	public $catWhere;
+
+	/**
 	 * @param array $options Class instances / Echo to CLI.
 	 */
 	public function __construct(array $options = [])
@@ -154,7 +159,7 @@ abstract class TV extends Videos
 				$status,
 				$this->catWhere,
 				($groupID === '' ? '' : 'AND r.group_id = ' . $groupID),
-				($guidChar === '' ? '' : 'AND r.guid ' . $this->pdo->likeString($guidChar, false, true)),
+				($guidChar === '' ? '' : 'AND r.leftguid = ' . $this->pdo->escapeString($guidChar)),
 				($lookupSetting == 2 ? 'AND r.isrenamed = 1' : ''),
 				$this->tvqty
 			)

--- a/resources/db/patches/mysql/+1~releases.sql
+++ b/resources/db/patches/mysql/+1~releases.sql
@@ -1,0 +1,8 @@
+# NOTE: Add leftguid column to releases and associated index for threaded lookups
+
+ALTER TABLE releases
+  ADD COLUMN leftguid CHAR(1) NOT NULL COMMENT 'The first letter of the release guid' AFTER guid,
+  ADD INDEX ix_releases_leftguid (leftguid ASC, predb_id);
+
+# NOTE: Populate existing releases with their leftmost guid character
+UPDATE releases SET leftguid = LEFT(guid, 1);

--- a/resources/db/schema/mysql-ddl.sql
+++ b/resources/db/schema/mysql-ddl.sql
@@ -698,6 +698,7 @@ CREATE TABLE         releases (
   INDEX ix_releases_group_id                  (group_id,passwordstatus),
   INDEX ix_releases_postdate_searchname       (postdate,searchname),
   INDEX ix_releases_guid                      (guid),
+  INDEX ix_releases_leftguid                  (leftguid ASC, predb_id),
   INDEX ix_releases_nzb_guid                  (nzb_guid),
   INDEX ix_releases_videos_id                 (videos_id),
   INDEX ix_releases_tv_episodes_id            (tv_episodes_id),

--- a/resources/db/schema/mysql-ddl.sql
+++ b/resources/db/schema/mysql-ddl.sql
@@ -657,6 +657,7 @@ CREATE TABLE         releases (
   adddate           DATETIME                       DEFAULT NULL,
   updatetime        TIMESTAMP                      NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   guid              VARCHAR(40)                    NOT NULL,
+  leftguid          CHAR(1)                        NOT NULL COMMENT 'The first letter of the release guid',
   fromname          VARCHAR(255)                   NULL,
   completion        FLOAT                          NOT NULL DEFAULT '0',
   categories_id     INT                            NOT NULL DEFAULT '0010',


### PR DESCRIPTION
Addresses issue #. None at this time.  Query performance is abysmal on larger databases making fixReleaseNames un-runnable.

Changes made by this pull request.
- Add leftguid column to releases after guid column.  Populate leftguid with LEFT(guid,1).
- Modify release insertion code to include the population of leftguid.
- Change threaded PP\rename work queries to use this column instead of doing LEFT() operations.
