### PR TITLE
Dev versions refactor

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -10,6 +10,10 @@ For details of when a commit makes it into the stable branch see the ReleaseNote
 
 
 2016-07-07 niel
+	Mrg: dev => Latest-testing to prepare for updating stable 0.x to v0.6.2.3.
+
+
+2016-07-07 niel
 	Add: Create new bootstrap file (.../bootstrap.php) to enable nzedb and lithium's app
 		libraries to load together.
 		 New files should use it as the base require_once instead of indexer.php. Old file will be

--- a/ReleaseNotes
+++ b/ReleaseNotes
@@ -6,7 +6,8 @@ Changes:
 	* Updated fxp/composer-asset-plugin dependency to v1.2.0
 
 Fixes:
-	* Create new bootstrap file (.../bootstrap.php) to enable nzedb and lithium's app libraries to load together.
+	* Create new bootstrap file (.../bootstrap.php) to enable nzedb and lithium's app libraries
+	 to load together. This fixes #2205.
 	  New files should use it as the base require_once instead of indexer.php. Old files will be
 	 converted over when it is convenient.
 

--- a/ReleaseNotes
+++ b/ReleaseNotes
@@ -1,6 +1,16 @@
 This file details which changes to the code are in which release version. It is a complement to the ChangeLog file which list *when* changes are made to the dev branch.
 
 
+0.6.2.3 2016-07-07
+Changes:
+	* Updated fxp/composer-asset-plugin dependency to v1.2.0
+
+Fixes:
+	* Create new bootstrap file (.../bootstrap.php) to enable nzedb and lithium's app libraries to load together.
+	  New files should use it as the base require_once instead of indexer.php. Old files will be
+	 converted over when it is convenient.
+
+
 0.6.2.2 2016-07-06
 Fixes:
 	* Other category not available on new installs, due to insert query still using 'category' table.

--- a/app/extensions/command/Version.php
+++ b/app/extensions/command/Version.php
@@ -86,8 +86,8 @@ class Version extends \app\extensions\console\Command
 			$this->primary('Looking up Git tag version(s)');
 		}
 		$this->out('Hash: ' . $this->versions->getGitHeadHash(), 0);
-		$this->out('XML version: ' . $this->versions->getGitTagFromFile());
-		$this->out('Git version: ' . $this->versions->getGitTagFromRepo());
+		$this->out('XML version: ' . $this->versions->getGitTagInFile());
+		$this->out('Git version: ' . $this->versions->getGitTagInRepo());
 	}
 
 	/**

--- a/app/extensions/util/Git.php
+++ b/app/extensions/util/Git.php
@@ -27,6 +27,8 @@ class Git extends \lithium\core\Object
 	 */
 	protected $repo;
 
+	protected $gitTagLatest = null;
+
 	private $branch;
 
 	public function __construct(array $config = [])
@@ -176,9 +178,12 @@ class Git extends \lithium\core\Object
 	 *
 	 * @return string
 	 */
-	public function tagLatest()
+	public function tagLatest($cached = true)
 	{
-		return $this->describe("--tags --abbrev=0 HEAD");
+		if (empty($this->gitTagLatest) || $cached === false) {
+			$this->gitTagLatest = $this->describe("--tags --abbrev=0 HEAD");
+		}
+		return $this->git->tagLatest();
 	}
 
 	protected function _init()

--- a/app/extensions/util/Git.php
+++ b/app/extensions/util/Git.php
@@ -183,7 +183,7 @@ class Git extends \lithium\core\Object
 		if (empty($this->gitTagLatest) || $cached === false) {
 			$this->gitTagLatest = $this->describe("--tags --abbrev=0 HEAD");
 		}
-		return $this->git->tagLatest();
+		return $this->gitTagLatest;
 	}
 
 	protected function _init()

--- a/app/extensions/util/Versions.php
+++ b/app/extensions/util/Versions.php
@@ -194,25 +194,23 @@ class Versions extends \lithium\core\Object
 	protected function loadXMLFile()
 	{
 		if (empty($this->versions)) {
-			$versions = $this->_config['path'];
-
 			$temp = libxml_use_internal_errors(true);
-			$this->xml = simplexml_load_file($versions);
+			$this->xml = simplexml_load_file($this->_config['path']);
 			libxml_use_internal_errors($temp);
 
 			if ($this->xml === false) {
-				$this->error("Your versions XML file ($versions) is broken, try updating from git.");
-				throw new \Exception("Failed to open versions XML file '$versions'");
+				$this->error("Your versions XML file ($this->_config['path']) is broken, try updating from git.");
+				throw new \Exception("Failed to open versions XML file '{$this->_config['path']}'");
 			}
 
 			if ($this->xml->count() > 0) {
-				$vers = $this->versions->xpath('/nzedb/versions');
+				$vers = $this->xml->xpath('/nzedb/versions');
 
 				if ($vers[0]->count() == 0) {
-					$this->error("Your versions XML file ($versions) does not contain version info, try updating from git.");
-					throw new \Exception("Failed to find versions node in XML file '$versions'");
+					$this->error("Your versions XML file ({$this->_config['path']}) does not contain version info, try updating from git.");
+					throw new \Exception("Failed to find versions node in XML file '{$this->_config['path']}'");
 				} else {
-					$this->versions = &$this->xml->versions;
+					$this->versions = &$this->xml->versions; // Create a convenience shortcut
 				}
 			} else {
 				throw new \RuntimeException("No elements in file!\n");

--- a/build/git-hooks/runHooks.php
+++ b/build/git-hooks/runHooks.php
@@ -22,9 +22,8 @@ define('GIT_PRE_COMMIT', true);
 
 require_once realpath(dirname(dirname(__DIR__)) . DIRECTORY_SEPARATOR . 'indexer.php');
 
-use nzedb\db\DbUpdate;
 use nzedb\utility\Git;
-use nzedb\utility\Versions;
+use app\extensions\util\Versions;
 
 echo "Running pre-commit hooks\n";
 

--- a/build/nzedb.xml
+++ b/build/nzedb.xml
@@ -2,7 +2,7 @@
 <nzedb>
 	<versions>
 		<git>
-			<tag>0.0.0</tag>
+			<tag>0.6.2</tag>
 			<!-- commit count removed Dec 2014 -->
 			<hooks>
 				<precommit>9</precommit>

--- a/composer.json
+++ b/composer.json
@@ -87,7 +87,7 @@
     "ext-spl": "*",
     "ext-xmlwriter": "*",
     "ext-zlib": "*",
-    "fxp/composer-asset-plugin": "~1.1.0",
+    "fxp/composer-asset-plugin": "~1.2.0",
     "giantbomb/giantbomb": "dev-master",
     "google/recaptcha": "^1.1.2",
     "james-heinrich/getid3": "^1.9.12",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "e165057c3355b690e063ec6f54e6ad21",
-    "content-hash": "4b4122cd268ef067db66f5d6f3974042",
+    "hash": "e937ef086199756b55245b1607941dcd",
+    "content-hash": "e402fa43c9d9c8542492b0cc0df3567d",
     "packages": [
         {
             "name": "barracudanetworks/forkdaemon-php",
@@ -994,16 +994,16 @@
         },
         {
             "name": "fxp/composer-asset-plugin",
-            "version": "v1.1.4",
+            "version": "v1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/fxpio/composer-asset-plugin.git",
-                "reference": "c3d803cc890fad5a7fb61a4036c5d973faae34af"
+                "reference": "8d74bc7c714aadbda54622c216b2e7bf786595cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fxpio/composer-asset-plugin/zipball/c3d803cc890fad5a7fb61a4036c5d973faae34af",
-                "reference": "c3d803cc890fad5a7fb61a4036c5d973faae34af",
+                "url": "https://api.github.com/repos/fxpio/composer-asset-plugin/zipball/8d74bc7c714aadbda54622c216b2e7bf786595cb",
+                "reference": "8d74bc7c714aadbda54622c216b2e7bf786595cb",
                 "shasum": ""
             },
             "require": {
@@ -1017,7 +1017,7 @@
             "extra": {
                 "class": "Fxp\\Composer\\AssetPlugin\\FxpAssetPlugin",
                 "branch-alias": {
-                    "dev-master": "1.1-dev"
+                    "dev-master": "1.2-dev"
                 }
             },
             "autoload": {
@@ -1036,7 +1036,7 @@
                 }
             ],
             "description": "NPM/Bower Dependency Manager for Composer",
-            "homepage": "https://github.com/francoispluchino/composer-asset-plugin",
+            "homepage": "https://github.com/fxpio/composer-asset-plugin",
             "keywords": [
                 "asset",
                 "bower",
@@ -1046,7 +1046,7 @@
                 "npm",
                 "package"
             ],
-            "time": "2016-04-22 08:48:58"
+            "time": "2016-07-01 12:04:16"
         },
         {
             "name": "giantbomb/giantbomb",

--- a/nzedb/Sites.php
+++ b/nzedb/Sites.php
@@ -54,7 +54,7 @@ class Sites
 
 	public function version()
 	{
-		return ($this->_versions === false ? '0.0.0' : $this->_versions->getGitTagFromRepo());
+		return ($this->_versions === false ? '0.0.0' : $this->_versions->getGitTagInRepo());
 	}
 
 	public function update($form)

--- a/nzedb/TmuxOutput.php
+++ b/nzedb/TmuxOutput.php
@@ -12,7 +12,7 @@ use nzedb\utility\Misc;
 class TmuxOutput extends Tmux
 {
 	/**
-	 * @var \nzedb\utility\Versions
+	 * @var \simpleXMLElement object
 	 */
 	protected $_vers;
 

--- a/nzedb/db/Settings.php
+++ b/nzedb/db/Settings.php
@@ -229,7 +229,7 @@ class Settings extends DB
 	public function version()
 	{
 		try {
-			$ver = (new Versions())->getGitTagFromRepo();
+			$ver = (new Versions())->getGitTagInRepo();
 		} catch (\Exception $e) {
 			$ver = '0.0.0';
 		}

--- a/nzedb/http/Capabilities.php
+++ b/nzedb/http/Capabilities.php
@@ -123,7 +123,7 @@ abstract class Capabilities
 
 		return [
 			'server' => [
-				'appversion' => (new Versions())->getTagVersion(),
+				'appversion' => (new Versions())->getGitTagInRepo(),
 				'version'    => '0.1',
 				'title'      => $this->pdo->getSetting('title'),
 				'strapline'  => $this->pdo->getSetting('strapline'),

--- a/nzedb/http/Capabilities.php
+++ b/nzedb/http/Capabilities.php
@@ -20,10 +20,10 @@
  */
 namespace nzedb\http;
 
+use app\extensions\util\Versions;
 use nzedb\Category;
 use nzedb\Utility\Misc;
 use nzedb\db\Settings;
-use nzedb\utility\Versions;
 
 /**
  * Class Output -- abstract class for printing web requests outside of Smarty

--- a/nzedb/utility/Misc.php
+++ b/nzedb/utility/Misc.php
@@ -1,6 +1,8 @@
 <?php
 namespace nzedb\utility;
 
+
+use app\extensions\util\Versions;
 use nzedb\ColorCLI;
 use nzedb\db\Settings;
 
@@ -280,9 +282,7 @@ class Misc
 
 	public static function getValidVersionsFile()
 	{
-		$versions = new Versions();
-
-		return $versions->getValidVersionsFile();
+		return (new Versions())->getValidVersionsFile();
 	}
 
 	/**

--- a/www/install/step2.php
+++ b/www/install/step2.php
@@ -1,6 +1,8 @@
 <?php
 require_once realpath(__DIR__ . DIRECTORY_SEPARATOR . 'install.php');
 
+
+use app\extensions\util\Versions;
 use nzedb\db\Settings;
 use nzedb\Install;
 
@@ -181,13 +183,11 @@ if ($page->isPostBack()) {
 				}
 			}
 
-			$ver = new \nzedb\utility\Versions();
-			$patch = $ver->getSQLPatchFromFiles();
+			$ver = new Versions();
+			$patch = $ver->getSQLPatchFromFile();
 			$pdo->setSetting(['..sqlpatch' => $patch]);
 
 			if ($dbInstallWorked) {
-				$ver   = new \nzedb\utility\Versions();
-				$patch = $ver->getSQLPatchFromFiles();
 				if ($patch > 0) {
 					$updateSettings = $pdo->setSetting(
 										[


### PR DESCRIPTION
Changes made by this pull request.
- Refactors scripts to use app\extensions\util\Versions class instead of the older nzedb\utility\Versions one.
- The newer class separates the logic from the reporting. i.e. it does not output messages to the user, instead it returns flags for the calling scripts to handle that output.
