### PR TITLE
Add UHD subcats to Movies, TV and XXX categories

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -9,6 +9,8 @@ NOT BE PRESENT IN THE STABLE BRANCH
 For details of when a commit makes it into the stable branch see the ReleaseNotes file.
 
 
+2016-07-20 DariusIII
+	Chg: Add UHD subcats to Movies, TV and XXX categories. Note: run recategorize script to populate the new cats
 2016-07-19 niel
 	Fix: Add lithium libraries bootstrap for Admin pages (Fixes issue 2215).
 2016-07-19 DariusIII

--- a/Changelog
+++ b/Changelog
@@ -10,7 +10,7 @@ For details of when a commit makes it into the stable branch see the ReleaseNote
 
 
 2016-07-20 DariusIII
-	Chg: Add UHD subcats to Movies, TV and XXX categories. Note: run recategorize script to populate the new cats
+	Chg: Add UHD subcats to Movies, TV and XXX categories. Note: run recategorize script to populate the new cats (php misc/testing/Release/recategorize.php all)
 2016-07-19 niel
 	Fix: Add lithium libraries bootstrap for Admin pages (Fixes issue 2215).
 2016-07-19 DariusIII

--- a/nzedb/Categorize.php
+++ b/nzedb/Categorize.php
@@ -161,6 +161,7 @@ class Categorize extends Category
 					break;
 				case $group === 'alt.binaries.british.drama':
 					switch (true) {
+						case $this->isUHDTV():
 						case $this->isHDTV():
 						case $this->isSDTV():
 						case $this->isPC():
@@ -397,6 +398,8 @@ class Categorize extends Category
 							break;
 						case $this->isMovieSD(): // Need to check this BEFORE the HD check
 							break;
+						case $this->isMovieUHD():  // Check the movie isn't an UHD release before blindly assigning SD
+							break;
 						case $this->isMovieHD():  // Check the movie isn't an HD release before blindly assigning SD
 							break;
 						default:
@@ -547,6 +550,7 @@ class Categorize extends Category
 				case $this->isDocumentaryTV():
 				case $this->catWebDL && $this->isWEBDL():
 				case $this->isAnimeTV():
+				case $this->isUHDTV():
 				case $this->isHDTV():
 				case $this->isSDTV():
 				case $this->isOtherTV2():
@@ -670,6 +674,15 @@ class Categorize extends Category
 		return false;
 	}
 
+	public function isUHDTV()
+	{
+		if (preg_match('/2160p/i', $this->releaseName)) {
+			$this->tmpCat = Category::TV_UHD;
+			return true;
+		}
+		return false;
+	}
+
 	public function isSDTV()
 	{
 		switch (true) {
@@ -706,6 +719,7 @@ class Categorize extends Category
 				case $this->isMovieSD():
 				case $this->isMovie3D():
 				case $this->isMovieBluRay():
+				case $this->isMovieUHD():
 				case $this->isMovieHD():
 				case $this->isMovieOther():
 					return true;
@@ -794,6 +808,15 @@ class Categorize extends Category
 			}
 		}
 
+		return false;
+	}
+
+	public function isMovieUHD()
+	{
+		if (preg_match('/2160p/i', $this->releaseName)) {
+			$this->tmpCat = Category::MOVIE_UHD;
+			return true;
+		}
 		return false;
 	}
 
@@ -909,6 +932,7 @@ class Categorize extends Category
 			case $this->isXxxPack():
 			case $this->isXxxSD():
 			case $this->catWebDL && $this->isXxxWEBDL():
+			case $this->isXxxUHD():
 			case $this->isXxx264():
 			case $this->isXxxXvid():
 			case $this->isXxxImageset():
@@ -934,6 +958,15 @@ class Categorize extends Category
 				$this->tmpCat = Category::XXX_X264;
 				return true;
 			}
+		}
+		return false;
+	}
+
+	public function isXxxUHD()
+	{
+		if (preg_match('/^[\w-.]+(\d{2}\.\d{2}\.\d{2}).+(2160p)+[\w-.]+(M[PO][V4]-(KTR|GUSH|FaiLED|SEXORS|hUSHhUSH|YAPG))/i', $this->releaseName)) {
+			$this->tmpCat = Category::XXX_UHD;
+			return true;
 		}
 		return false;
 	}

--- a/nzedb/Category.php
+++ b/nzedb/Category.php
@@ -36,6 +36,7 @@ class Category
 	const MOVIE_DVD = '2070';
 	const MOVIE_FOREIGN = '2010';
 	const MOVIE_HD = '2040';
+	const MOVIE_UHD = '2045';
 	const MOVIE_OTHER = '2999';
 	const MOVIE_ROOT = '2000';
 	const MOVIE_SD = '2030';
@@ -62,6 +63,7 @@ class Category
 	const TV_DOCUMENTARY = '5080';
 	const TV_FOREIGN = '5020';
 	const TV_HD = '5040';
+	const TV_UHD = '5045';
 	const TV_OTHER = '5999';
 	const TV_ROOT = '5000';
 	const TV_SD = '5030';
@@ -76,6 +78,7 @@ class Category
 	const XXX_WEBDL = '6090';
 	const XXX_WMV = '6020';
 	const XXX_X264 = '6040';
+	const XXX_UHD = '6045';
 	const XXX_XVID = '6030';
 
 	const STATUS_INACTIVE = 0;

--- a/resources/db/patches/mysql/+1~categories.sql
+++ b/resources/db/patches/mysql/+1~categories.sql
@@ -1,0 +1,5 @@
+# Add new UHD categories to Movies, TV and XXX
+
+INSERT IGNORE INTO categories (id, title, parentid) VALUES (2045, 'UHD', 2000);
+INSERT IGNORE INTO categories (id, title, parentid) VALUES (5045, 'UHD', 5000);
+INSERT IGNORE INTO categories (id, title, parentid) VALUES (6045, 'UHD', 6000);

--- a/resources/db/schema/data/10-categories.tsv
+++ b/resources/db/schema/data/10-categories.tsv
@@ -25,6 +25,7 @@ id, title, parentid
 2010	Foreign	2000
 2030	SD	2000
 2040	HD	2000
+2045	UHD	2000
 2050	3D	2000
 2060	BluRay	2000
 2070	DVD	2000
@@ -47,6 +48,7 @@ id, title, parentid
 5020	Foreign	5000
 5030	SD	5000
 5040	HD	5000
+5045	UHD	5000
 5060	Sport	5000
 5070	Anime	5000
 5080	Documentary	5000
@@ -55,6 +57,7 @@ id, title, parentid
 6020	WMV	6000
 6030	XviD	6000
 6040	x264	6000
+6045	UHD		6000
 6060	Imageset	6000
 6070	Packs	6000
 6080	SD	6000


### PR DESCRIPTION
Addresses no issue. 

Changes made by this pull request.
- Add UHD subcategories to Movies, TV and XXX categories for 2160p (aka 4k) releases
