### PR TITLE
remove rogue semicolon

### DIFF
--- a/resources/db/schema/mysql-ddl.sql
+++ b/resources/db/schema/mysql-ddl.sql
@@ -1089,7 +1089,7 @@ CREATE TABLE role_excluded_categories
     categories_id   INT(11),
     createddate     DATETIME NOT NULL,
     PRIMARY KEY (id),
-    UNIQUE INDEX ix_roleexcat_rolecat (role, categories_id);
+    UNIQUE INDEX ix_roleexcat_rolecat (role, categories_id)
 )
     ENGINE = MyISAM
     DEFAULT CHARSET = utf8


### PR DESCRIPTION
This extra semicolon caused the database to be partially created causing further issues with the site after the install process was complete.
