### PR TITLE
Check for incompatible tmux versions and abort if installed.

### DIFF
--- a/misc/update/nix/tmux/start.php
+++ b/misc/update/nix/tmux/start.php
@@ -13,6 +13,16 @@ use nzedb\db\DB;
 
 $pdo = new DB();
 
+// Ensure compatible tmux version is installed
+if (`which tmux`) {
+        $tmux_version = shell_exec('tmux -V');
+        if ($tmux_version == "tmux 2.1\n" || $tmux_version == "tmux 2.2\n") {
+                exit($pdo->log->error("tmux versions 2.1 and 2.2 are not compatible with nZEDb. Aborting\n"));
+                }
+} else {
+        exit($pdo->log->error("tmux binary not found. Aborting\n"));
+}
+
 $tmux = new Tmux();
 $tmux_settings = $tmux->get();
 $tmux_session = (isset($tmux_settings->tmux_session)) ? $tmux_settings->tmux_session : 0;


### PR DESCRIPTION
Addresses issue #2182 

Changes made by this pull request.
- Have start.php check the installed tmux version. Abort if not found or incompatible.

Note: Please have a look the the IF test on line 19. I imagine that there is a "cleaner" way  to do this in PHP.
