### PR TITLE
Update resetdb.php

### DIFF
--- a/misc/testing/DB/resetdb.php
+++ b/misc/testing/DB/resetdb.php
@@ -39,7 +39,8 @@ $arr = [
 		"videos", "tv_episodes", "tv_info", "release_nfos", "release_comments", 'sharing', 'sharing_sites',
 		"users_releases", "user_movies", "user_series", "movieinfo", "musicinfo", "release_files",
 		"audio_data", "release_subtitles", "video_data", "releaseextrafull", "parts",
-		"missed_parts", "binaries", "collections", "releases", "anidb_titles", "anidb_info", "anidb_episodes"
+		"missed_parts", "binaries", "collections", "releases", "anidb_titles", "anidb_info", "anidb_episodes",
+		"releases_groups"
 ];
 
 // Truncate applicable tables


### PR DESCRIPTION
Newer table "releases_groups" wasn't added to script. Caused subsequent runs of release update scripts to silently exit leaving "duplicate PRIMARY key" errors in logs. Perhaps also missing from other scripts but don't have the knowledge of code base to hunt them all down.
