### PR TITLE
Default movie process quantity to 100 if not specified, else use setting.

### DIFF
--- a/nzedb/Movie.php
+++ b/nzedb/Movie.php
@@ -166,7 +166,7 @@ class Movie
 		$this->fanartapikey = Settings::value('APIs..fanarttvkey');
 		$this->imdburl = (Settings::value('indexer.categorise.imdburl') == 0 ? false : true);
 		$result = Settings::value('..maximdbprocessed');
-		$this->movieqty = empty($result) ? $result : 100;
+		$this->movieqty = empty($result) ? 100 : $result;
 		$this->searchEngines = true;
 		$this->showPasswords = Releases::showPasswords();
 


### PR DESCRIPTION
Addresses issue: currently 100 movies are always processed ignoring the user settings.

Changes made by this pull request.
- change if statement to load 100 should empty param be passed.
-
-
