### PR TITLE
Fix `zed update nzedb`

### DIFF
--- a/app/extensions/command/Update.php
+++ b/app/extensions/command/Update.php
@@ -111,7 +111,10 @@ class Update extends \app\extensions\console\Command
 			return;
 		}
 
-		$this->out($this->git->pull());
+		$output = $this->git->pull();
+		$this->out($output);
+		
+		return trim($output);
 	}
 
 	public function nzedb()


### PR DESCRIPTION
Updating was failing prematurely because `Update::nzedb()` expects `Update::git()` to return the output of the `Update::git->pull()`. This commit adjusts `Update::git()` to not only output the response from `Update::git->pull()`, but also to return the trimmed value for evaluation in `Update::nzedb()`, allowing the update to continue.