### PR TITLE
Fix path to config.php

### DIFF
--- a/misc/update/python/lib/info.py
+++ b/misc/update/python/lib/info.py
@@ -50,7 +50,7 @@ def disconnect(cur, con):
 
 
 def readConfig():
-    Configfile = pathname+"/../../../nzedb/config/config.php"
+    Configfile = pathname+"/../../../configuration/config.php"
     file = open( Configfile, "r")
 
     # Match a config line


### PR DESCRIPTION
My backfill pane shows an error after updating to 0.7 because info.py still has the old location of config.php set.