### PR TITLE
Update tmux configs for tmux 2.4

### DIFF
--- a/misc/update/nix/tmux/powerline/tmux.conf
+++ b/misc/update/nix/tmux/powerline/tmux.conf
@@ -9,7 +9,6 @@ set-window-option -g utf8 on
 # Allows for faster key repetition
 set -s escape-time 0
 
-set -g set-remain-on-exit on
 set -g default-terminal "screen-256color"
 
 ## Powerline Statusbar ##
@@ -37,7 +36,7 @@ set-window-option -g window-status-current-format "#[fg=colour235, bg=colour27]‚
 set-window-option -g window-status-format "#[fg=colour114, bg=colour27]#[fg=colour114, bg=colour27] #I‚ÆÅ #W #[fg=colour27, bg=colour114]"
 
 #reduce memory and scrollback buffer
-set -g history-limit 3000
+set -g history-limit 5000
 
 # Thanks to http://stackoverflow.com/questions/34187900/tmux-enabling-mouse-support-across-different-versions
 #     Note: must be last line for tmux <=1.8

--- a/misc/update/nix/tmux/powerline/tmux_ge_2.3.conf
+++ b/misc/update/nix/tmux/powerline/tmux_ge_2.3.conf
@@ -26,11 +26,14 @@ bind -T root MouseDown1Pane select-pane -t=
 
 # This allows you to press page up in normal mode and have it scroll back into the history...
 bind-key -T root PPage if-shell -F "#{alternate_on}" "send-keys PPage" "copy-mode -e; send-keys PPage"
-bind-key -t vi-copy PPage page-up
-bind-key -t vi-copy NPage page-down
+# bind-key -t vi-copy PPage page-up
+# bind-key -t vi-copy NPage page-down
 
 # Very similar to page up, except for the mouse wheel.
 bind-key -T root WheelUpPane if-shell -F -t = "#{alternate_on}" "send-keys -M" "select-pane -t =; copy-mode -e; send-keys -M"
 bind-key -T root WheelDownPane if-shell -F -t = "#{alternate_on}" "send-keys -M" "select-pane -t =; send-keys -M"
-bind-key -t vi-copy WheelUpPane scroll-up       # For faster wheel scrolling replace scroll-up with halfpage-up
-bind-key -t vi-copy WheelDownPane scroll-down   # For faster wheel scrolling replace scroll-up with halfpage-down
+# bind-key -t vi-copy WheelUpPane scroll-up       # For faster wheel scrolling replace scroll-up with halfpage-up
+# bind-key -t vi-copy WheelDownPane scroll-down   # For faster wheel scrolling replace scroll-up with halfpage-down
+
+# Keep pane open after process ends - monitor.php requires this for re-spawns (the only config param nZEDB really needs)
+if-shell "tmux -V |awk ' {split($2, ver, \".\"); if (ver[1] == 2 && ver[2] > 3) exit 1 }' " 'set -g set-remain-on-exit on' 'set -g remain-on-exit on'

--- a/misc/update/nix/tmux/powerline/tmux_le_2.0.conf
+++ b/misc/update/nix/tmux/powerline/tmux_le_2.0.conf
@@ -19,3 +19,6 @@ bind M \
  set -g mouse-select-pane off \;\
  set -g mouse-select-window off \;\
  display 'Mouse: OFF'
+
+# Keep pane open after process ends - monitor.php requires this for re-spawns (the only config param nZEDB really needs)
+set -g set-remain-on-exit on

--- a/misc/update/nix/tmux/tmux.conf
+++ b/misc/update/nix/tmux/tmux.conf
@@ -11,8 +11,8 @@ setw -g mode-keys vi
 set -s escape-time 0
 
 #set 256 color display
-#set -g default-terminal "screen-256color"
-set -g default-terminal "xterm-256color"
+set -g default-terminal "screen-256color"
+# set -g default-terminal "xterm-256color"
 
 # Set status bar
 set -g status-bg black
@@ -24,10 +24,6 @@ set -g status-right "#[fg=green]#H"
 # connected to the *session*, constrain window size to the maximum size of any
 # client connected to *that window*. Much more reasonable.
 setw -g aggressive-resize on
-
-## Allows us to use C-a a <command> to send commands to a TMUX session inside
-## another TMUX session
-# bind-key a send-prefix
 
 # Activity monitoring
 setw -g monitor-activity on
@@ -51,10 +47,7 @@ set-option -g status-right-length 200
 set-window-option -g window-status-current-bg red
 
 # Scrollback line buffer per pane
-set -g history-limit 3000   # reduce for memory limited systems (say <=8Gb)
-
-# Keep pane open after process ends - monitor.php requires this for re-spawns (the only config param nZEDB really needs)
-set -g set-remain-on-exit on
+set -g history-limit 5000   # reduce for memory limited systems (say <=8Gb)
 
 # Thanks to http://stackoverflow.com/questions/34187900/tmux-enabling-mouse-support-across-different-versions
 #     Note: must be last line for tmux <=1.8

--- a/misc/update/nix/tmux/tmux_ge_2.3.conf
+++ b/misc/update/nix/tmux/tmux_ge_2.3.conf
@@ -26,11 +26,14 @@ bind -T root MouseDown1Pane select-pane -t=
 
 # This allows you to press page up in normal mode and have it scroll back into the history...
 bind-key -T root PPage if-shell -F "#{alternate_on}" "send-keys PPage" "copy-mode -e; send-keys PPage"
-bind-key -t vi-copy PPage page-up
-bind-key -t vi-copy NPage page-down
+# bind-key -t vi-copy PPage page-up
+# bind-key -t vi-copy NPage page-down
 
 # Very similar to page up, except for the mouse wheel.
 bind-key -T root WheelUpPane if-shell -F -t = "#{alternate_on}" "send-keys -M" "select-pane -t =; copy-mode -e; send-keys -M"
 bind-key -T root WheelDownPane if-shell -F -t = "#{alternate_on}" "send-keys -M" "select-pane -t =; send-keys -M"
-bind-key -t vi-copy WheelUpPane scroll-up       # For faster wheel scrolling replace scroll-up with halfpage-up
-bind-key -t vi-copy WheelDownPane scroll-down   # For faster wheel scrolling replace scroll-up with halfpage-down
+# bind-key -t vi-copy WheelUpPane scroll-up       # For faster wheel scrolling replace scroll-up with halfpage-up
+# bind-key -t vi-copy WheelDownPane scroll-down   # For faster wheel scrolling replace scroll-up with halfpage-down
+
+# Keep pane open after process ends - monitor.php requires this for re-spawns (the only config param nZEDB really needs)
+if-shell "tmux -V |awk ' {split($2, ver, \".\"); if (ver[1] == 2 && ver[2] > 3) exit 1 }' " 'set -g set-remain-on-exit on' 'set -g remain-on-exit on'

--- a/misc/update/nix/tmux/tmux_le_2.0.conf
+++ b/misc/update/nix/tmux/tmux_le_2.0.conf
@@ -19,3 +19,6 @@ bind M \
  set -g mouse-select-pane off \;\
  set -g mouse-select-window off \;\
  display 'Mouse: OFF'
+
+# Keep pane open after process ends - monitor.php requires this for re-spawns (the only config param nZEDB really needs)
+set -g set-remain-on-exit on


### PR DESCRIPTION
Changes made by this pull request:

- Adjust tmux configs for tmux v2.4. #2394
- Increase pane scrollback buffer to 5000 lines.
- Change default-terminal to screen-256color. #2403 #2434 

Note: tmux modes sequential-disabled and basic-sequential unfortunately still do not work with tmux v2.3 and v2.4 :/  Am looking into this.
