### PR TITLE
Implementing proper maintenance mode

### DIFF
--- a/configuration/settings.example.php
+++ b/configuration/settings.example.php
@@ -18,7 +18,7 @@ use nzedb\utility\Misc;
  *                    $current_settings_file_version in nzedb\config\Configure.php
  * @version 4
  */
-define('nZEDb_SETTINGS_FILE_VERSION', 4);
+define('nZEDb_SETTINGS_FILE_VERSION', 5);
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////// Web Settings ////////////////////////////////////////////////
@@ -535,6 +535,47 @@ define('PHPMAILER_SMTP_USER', '');
  * @default ''
  */
 define('PHPMAILER_SMTP_PASSWORD', '');
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////// Maintenance Mode Settings //////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+/**
+ * Should the site be in maintenance mode. If enabled, it will output the selected HTML file added below to front-end
+ * pages as well as outputting a properly formatted API error response with the error text "Maintenance Mode" and error
+ * code 503.
+ *
+ * This will prevent nZEDb from making any MySQL/Sphinx/Cache calls so it's good to use this if you need to stop/restart
+ * those services.
+ *
+ * @note If your site uses some form of webserver-level caching, the cache may need to be cleared when coming out of
+ *       maintenance mode. Otherwise you'll have to wait until it expires to see your proper site again.
+ *
+ * @default false
+ */
+define('MAINTENANCE_MODE_ENABLED', false);
+
+/**
+ * The fully qualified absolute path to the maintenance mode HTML file. This should be a fully complete HTML file and
+ * NOT a smarty template. The idea of a maintenance file is it should be static HTML with no dependencies on other systems.
+ * That way it can safely be displayed without the database running or any other services (except PHP and the webserver
+ * of course).
+ *
+ * @note On my site I ripped the rendered HTML content of my home page and swapped out the center container for a maintenance
+ * message. This is a good process. Be sure to remove all references to user data. Links to other site pages can remain intact.
+ *
+ * @default ''
+ */
+define('MAINTENANCE_MODE_HTML_PATH', '');
+
+/**
+ * What IP addresses should be excluded from maintenance mode. Useful if you want to allow admins to access the site while
+ * everyone else sees the maintenance message.
+ *
+ * @note Keep in mind, if your site uses ipv6 you may need to enter your ipv6 address here as well.
+ *
+ * @default []
+ */
+define('MAINTENANCE_MODE_IP_EXCEPTIONS', []);
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////// PHP CLI Settings ////////////////////////////////////////////////

--- a/nzedb/utility/Misc.php
+++ b/nzedb/utility/Misc.php
@@ -861,6 +861,9 @@ class Misc
 				case 501:
 					$errorText = 'Download limit reached';
 					break;
+                case 503:
+                    $errorText = 'Maintenance Mode';
+                    break;
 				default:
 					$errorText = 'Unknown error';
 					break;

--- a/www/index.php
+++ b/www/index.php
@@ -66,6 +66,7 @@ switch ($page->page) {
 	case 'upcoming':
 	case 'xxx':
 	case 'xxxmodal':
+        $page->maintenanceCheck();
 		// Don't show these pages if it's an API-only site.
 		if (!$page->users->isLoggedIn()) {
 			if (Settings::value('..registerstatus') == Settings::REGISTER_STATUS_API_ONLY) {
@@ -78,10 +79,11 @@ switch ($page->page) {
 				$page->page = 'login';
 			}
 		}
-	case 'api':
+    case 'login':
+        $page->maintenanceCheck();
+    case 'api':
 	case 'failed':
 	case 'getnzb':
-	case 'login':
 	case 'preinfo':
 	case 'rss':
 		require_once(nZEDb_WWW . 'pages/' . $page->page . '.php');

--- a/www/pages/Page.php
+++ b/www/pages/Page.php
@@ -91,4 +91,21 @@ class Page extends BasePage
 
 		parent::render();
 	}
+
+    private function outputMaintenanceMessage() {
+        readfile(MAINTENANCE_MODE_HTML_PATH);
+        exit();
+    }
+
+    public function maintenanceCheck($outputMessage = true) {
+        if (MAINTENANCE_MODE_ENABLED &&
+            !in_array($_SERVER['REMOTE_ADDR'], MAINTENANCE_MODE_IP_EXCEPTIONS) &&
+            file_exists(MAINTENANCE_MODE_HTML_PATH)) {
+            if ($outputMessage) {
+                $this->outputMaintenanceMessage();
+            }
+            return true;
+        }
+        return false;
+    }
 }

--- a/www/pages/api.php
+++ b/www/pages/api.php
@@ -7,6 +7,10 @@ use nzedb\db\DB;
 use nzedb\utility\Misc;
 use nzedb\utility\Text;
 
+if ($page->maintenanceCheck(false)) {
+    Misc::showApiError(503);
+}
+
 // API functions.
 $function = 's';
 if (isset($_GET['t'])) {

--- a/www/pages/failed.php
+++ b/www/pages/failed.php
@@ -3,6 +3,11 @@
 use app\models\Settings;
 use nzedb\DnzbFailures;
 use nzedb\db\DB;
+use nzedb\utility\Misc;
+
+if ($page->maintenanceCheck(false)) {
+    Misc::showApiError(503);
+}
 
 // Page is accessible only by the rss token, or logged in users.
 if ($page->users->isLoggedIn()) {

--- a/www/pages/getnzb.php
+++ b/www/pages/getnzb.php
@@ -6,6 +6,10 @@ use nzedb\NZB;
 use nzedb\db\DB;
 use nzedb\utility\Misc;
 
+if ($page->maintenanceCheck(false)) {
+    Misc::showApiError(503);
+}
+
 $uid = 0;
 
 // Page is accessible only by the rss token, or logged in users.

--- a/www/pages/rss.php
+++ b/www/pages/rss.php
@@ -6,6 +6,10 @@ use nzedb\http\RSS;
 use nzedb\db\DB;
 use nzedb\utility\Misc;
 
+if ($page->maintenanceCheck(false)) {
+    Misc::showApiError(503);
+}
+
 $category = new Category(['Settings' => $page->settings]);
 $rss = new RSS(['Settings' => $page->settings]);
 $offset = 0;


### PR DESCRIPTION
This allows users to enable maintenance mode from the settings.php file. It will output the listed HTML file as well as a properly-formatted XML response for the api endpoints. 
