### PR TITLE
FIX anidb_info -> categories

### DIFF
--- a/nzedb/db/populate/AniDB.php
+++ b/nzedb/db/populate/AniDB.php
@@ -155,7 +155,7 @@ class AniDB
 			$AniDBAPIArray['related'] = $this->processAPIResponseElement($AniDBAPIXML->relatedanime, 'anime', false);
 			$AniDBAPIArray['creators'] = $this->processAPIResponseElement($AniDBAPIXML->creators, null, false);
 			$AniDBAPIArray['characters'] = $this->processAPIResponseElement($AniDBAPIXML->characters, null, true);
-			$AniDBAPIArray['categories'] = $this->processAPIResponseElement($AniDBAPIXML->categories, null, true);
+			$AniDBAPIArray['categories'] = $this->processAPIResponseElement($AniDBAPIXML->tags, null, true);
 
 			$episodeArray = [];
 			if ($AniDBAPIXML->episodes && $AniDBAPIXML->episodes->episode[0]->attributes()) {

--- a/www/themes/Charisma/templates/basepage.tpl
+++ b/www/themes/Charisma/templates/basepage.tpl
@@ -186,6 +186,8 @@
 <!-- jQuery -->
 <script type="text/javascript"
 		src="{$smarty.const.WWW_THEMES}/shared/libs/jquery-2.2.x/dist/jquery.min.js"></script>
+<!-- library for iphone style toggles -->
+<script type="text/javascript" src="{$smarty.const.WWW_THEMES}/{$theme}/js/jquery.iphone.toggle.js"></script>
 <!-- jQuery migrate script -->
 <script type="text/javascript"
 		src="{$smarty.const.WWW_THEMES}/shared/libs/jquery-migrate-1.4.x/jquery-migrate.min.js"></script>
@@ -239,13 +241,13 @@
 <![endif]-->
 
 <!-- PNotify -->
-<script type="text/javascript" src="{$smarty.const.WWW_THEMES}/shared/assets/pnotify/dist/pnotify.js"></script>
-<script type="text/javascript" src="{$smarty.const.WWW_THEMES}/shared/assets/pnotify/dist/pnotify.animate.js"></script>
-<script type="text/javascript" src="{$smarty.const.WWW_THEMES}/shared/assets/pnotify/dist/pnotify.desktop.js"></script>
-<script type="text/javascript" src="{$smarty.const.WWW_THEMES}/shared/assets/pnotify/dist/pnotify.callbacks.js"></script>
-<script type="text/javascript" src="{$smarty.const.WWW_THEMES}/shared/assets/pnotify/dist/pnotify.buttons.js"></script>
-<script type="text/javascript" src="{$smarty.const.WWW_THEMES}/shared/assets/pnotify/dist/pnotify.confirm.js"></script>
-<script type="text/javascript" src="{$smarty.const.WWW_THEMES}/shared/assets/pnotify/dist/pnotify.nonblock.js"></script>
+<script type="text/javascript" src="{$smarty.const.WWW_THEMES}/shared/libs/pnotify-3.0.x/dist/pnotify.js"></script>
+<script type="text/javascript" src="{$smarty.const.WWW_THEMES}/shared/libs/pnotify-3.0.x/dist/pnotify.animate.js"></script>
+<script type="text/javascript" src="{$smarty.const.WWW_THEMES}/shared/libs/pnotify-3.0.x/dist/pnotify.desktop.js"></script>
+<script type="text/javascript" src="{$smarty.const.WWW_THEMES}/shared/libs/pnotify-3.0.x/dist/pnotify.callbacks.js"></script>
+<script type="text/javascript" src="{$smarty.const.WWW_THEMES}/shared/libs/pnotify-3.0.x/dist/pnotify.buttons.js"></script>
+<script type="text/javascript" src="{$smarty.const.WWW_THEMES}/shared/libs/pnotify-3.0.x/dist/pnotify.confirm.js"></script>
+<script type="text/javascript" src="{$smarty.const.WWW_THEMES}/shared/libs/pnotify-3.0.x/dist/pnotify.nonblock.js"></script>
 
 <script type="text/javascript">
     tinyMCE.init({

--- a/www/themes/Charisma/templates/viewnzb.tpl
+++ b/www/themes/Charisma/templates/viewnzb.tpl
@@ -147,14 +147,17 @@
 									{if ($release.haspreview == 1 && $userdata.canpreview == 1) || ($release.haspreview == 2 && $userdata.canpreview == 1)}
 										<li><a href="#pane7" data-toggle="tab">Preview</a></li>
 									{/if}
+									{if ($release.videostatus == 1 && $userdata.canpreview == 1)}
+										<li><a href="#pane8" data-toggle="tab">Video Sample</a></li>
+									{/if}
 									{if $reVideo.releases_id|@count > 0 || $reAudio|@count > 0}
-										<li><a href="#pane8" data-toggle="tab">MediaInfo</a></li>
+										<li><a href="#pane9" data-toggle="tab">MediaInfo</a></li>
 									{/if}
 									{if isset($xxx.backdrop) && $xxx.backdrop == 1}
-										<li><a href="#pane9" data-toggle="tab">Back Cover</a></li>
+										<li><a href="#pane10" data-toggle="tab">Back Cover</a></li>
 									{/if}
 									{if isset($game.backdrop) && $game.backdrop == 1}
-									<li><a href="#pane10" data-toggle="tab">Screenshot</a></li>
+									<li><a href="#pane11" data-toggle="tab">Screenshot</a></li>
 									{/if}
 								</ul>
 								<div class="tab-content">
@@ -635,8 +638,13 @@
 												 data-target="#modal-image"/>
 										</div>
 									{/if}
-									{if $reVideo.releases_id|@count > 0 || $reAudio|@count > 0}
+									{if ($release.videostatus == 1 && $userdata.canpreview == 1)}
 										<div id="pane8" class="tab-pane">
+											<video width="450" controls><source src="{$smarty.const.WWW_TOP}/covers/video/{$release.guid}.ogv" type="video/ogg">Your browser does not support the video tag.</video>
+										</div>
+									{/if}
+									{if $reVideo.releases_id|@count > 0 || $reAudio|@count > 0}
+										<div id="pane9" class="tab-pane">
 											<table style="width:100%;"
 												   class="data table table-condensed table-striped table-responsive table-hover">
 												<tr>
@@ -782,7 +790,7 @@
 										</div>
 									{/if}
 									{if isset($xxx.backdrop) && $xxx.backdrop == 1}
-										<div id="pane9" class="tab-pane">
+										<div id="pane10" class="tab-pane">
 											<img src="{$smarty.const.WWW_TOP}/covers/xxx/{$xxx.id}-backdrop.jpg"
 												 alt="{$xxx.title|escape:"htmlall"}"
 												 data-toggle="modal"
@@ -790,7 +798,7 @@
 										</div>
 									{/if}
 									{if isset($game.backdrop) && $game.backdrop == 1}
-										<div id="pane10" class="tab-pane">
+										<div id="pane11" class="tab-pane">
 											<img src="{$smarty.const.WWW_TOP}/covers/games/{$game.id}-backdrop.jpg"
 												 alt="{$game.title|escape:"htmlall"}"
 												 data-toggle="modal"


### PR DESCRIPTION
I don't know if anidb changed this from categories, or just removed it altogether.  What I do know is it leaves categories blank, and tags looks an awful like categories so I adjusted it to scape the tags for this field.

Changes made by this pull request.
-
Instead of parsing for categories from the AniDB API, since its non existent it parses tags for the categories
