### PR TITLE
fix invalid updated datetime value

### DIFF
--- a/nzedb/IRCScraper.php
+++ b/nzedb/IRCScraper.php
@@ -322,7 +322,7 @@ class IRCScraper extends IRCClient
 		$data = [
 			'title' => $this->_curPre['title'],
 			'created' => $this->_curPre['predate']->format('Y-m-d H:i:s'),
-			'updated' => '0000-00-00 00:00:00',
+			'updated' => $this->_curPre['predate']->format('Y-m-d H:i:s'),
 		];
 
 


### PR DESCRIPTION
Addresses issue nZEDb#2621.

Per SO's question on datetime 0000-00-00-000000, it looks like 0000-00-00-000000 is actually invalid and causes the returned value of -0001-11-30 00:00:00. This fails inserts into the PreDB table.

Changing the initial updated datetime value to be the same as the created datetime value makes the most sense and prevents the invalid datetime value.