### PR TITLE
Better movie (IMDB) lookups

### DIFF
--- a/ReleaseNotes
+++ b/ReleaseNotes
@@ -2,6 +2,11 @@ This file details which changes to the code are in which release version. It is 
 ChangeLog file which list *when* changes are made to the dev branches.
 
 
+0.8.17.1 2019-06-03
+Fixed:
+	* Typo in variable name.
+
+
 0.8.17.0 2019-06-03
 Changed:
 	* Improvements to how TSV files are handled to make LOAD INFILE less problematic.

--- a/app/extensions/command/Update.php
+++ b/app/extensions/command/Update.php
@@ -100,7 +100,7 @@ class Update extends \app\extensions\console\Command
 			$this->out('Up to date.', 'info');
 		}
 
-		return $this->migrate();
+		//return $this->migrate();
 	}
 
 	public function git()

--- a/build/nzedb.xml
+++ b/build/nzedb.xml
@@ -2,7 +2,7 @@
 <nzedb>
 	<versions>
 		<git>
-			<tag>0.0.0-dev</tag>
+			<tag>0.8.17.0</tag>
 			<!-- commit count removed Dec 2014 -->
 			<hooks>
 				<precommit>9</precommit>

--- a/build/nzedb.xml
+++ b/build/nzedb.xml
@@ -2,7 +2,7 @@
 <nzedb>
 	<versions>
 		<git>
-			<tag>0.8.17.1</tag>
+			<tag>0.8.17.2</tag>
 			<!-- commit count removed Dec 2014 -->
 			<hooks>
 				<precommit>9</precommit>

--- a/build/nzedb.xml
+++ b/build/nzedb.xml
@@ -2,7 +2,7 @@
 <nzedb>
 	<versions>
 		<git>
-			<tag>0.8.17.0</tag>
+			<tag>0.8.17.1</tag>
 			<!-- commit count removed Dec 2014 -->
 			<hooks>
 				<precommit>9</precommit>

--- a/build/nzedb.xml
+++ b/build/nzedb.xml
@@ -2,7 +2,7 @@
 <nzedb>
 	<versions>
 		<git>
-			<tag>0.8.17.2</tag>
+			<tag>0.8.17.1</tag>
 			<!-- commit count removed Dec 2014 -->
 			<hooks>
 				<precommit>9</precommit>

--- a/nzedb/Movie.php
+++ b/nzedb/Movie.php
@@ -1447,14 +1447,14 @@ class Movie
 	protected function parseMovieSearchName($releaseName)
 	{
 		$name = $year = '';
-		$followingList = '[^\w]((1080|480|720)p|AC3D|Directors([^\w]CUT)?|DD5\.1|(DVD|BD|BR)(Rip)?|BluRay|divx|HDTV|iNTERNAL|LiMiTED|(Real\.)?Proper|RE(pack|Rip)|Sub\.?(fix|pack)|Unrated|WEB-DL|(x|H)[-._ ]?264|xvid)[^\w]';
+		$followingList = '[^\w]((2160|1080|480|720)p|(BD|DVD|BR|WEB|WEBHD|HDTV|VHS|TV)Rip|German|(x|h)x26(4|5)|xvid|Dubbed|Subbed|AC3(.MD|MD|D|LD)|(HD)CAM|MiC|iNTERNAL|TS|LD|TC|DL|PAL|DVD(R)|3D|Complete|KiNOFASSUNG|Remastered|Proper|Repack|UNCUT|DTS(D|HD)|Unrated|WEB-DL|DD5\.1|Directors([^\w]CUT)?|BluRay|AVC|UHD|Remux|DUAL.COMPLETE|MULTi|HEVC)[^\w]';
 
 		/* Initial scan of getting a year/name.
 		 * [\w. -]+ Gets 0-9a-z. - characters, most scene movie titles contain these chars.
 		 * ie: [61420]-[FULL]-[a.b.foreignEFNet]-[ Coraline.2009.DUTCH.INTERNAL.1080p.BluRay.x264-VeDeTT ]-[21/85] - "vedett-coralien-1080p.r04" yEnc
 		 * Then we look up the year, (19|20)\d\d, so $matches[1] would be Coraline $matches[2] 2009
 		 */
-		if (preg_match('/(?P<name>[\w. -]+)[^\w](?P<year>(19|20)\d\d)/i', $releaseName, $matches)) {
+		if (preg_match('/(?P<name>[\w. -]+)' . $followingList . '(?P<year>(19|20)\d\d)/i', $releaseName, $matches)) {
 			$name = $matches['name'];
 			$year = $matches['year'];
 

--- a/nzedb/db/DB.php
+++ b/nzedb/db/DB.php
@@ -1,5 +1,6 @@
 <?php
 namespace nzedb\db;
+include_once__DIR__ . '/../../settings.php';
 
 use nzedb\ColorCLI;
 use nzedb\ConsoleTools;


### PR DESCRIPTION
Addresses issue #.
inaccurate IMDB lookups for movies foreign and native language.

Changes made by this pull request.
-additional "releasename parts" like "HEVC" for $followingList are added/reworked

-and avoid of matching any of entries of $followingList to count as moviename to gain a better lookup experience.
