### PR TITLE
Update NZBimport.php: fix group shortnames 

### DIFF
--- a/nzedb/NZBImport.php
+++ b/nzedb/NZBImport.php
@@ -300,15 +300,18 @@ class NZBImport
 				$group = (string)$group;
 
 				// If groups_id is -1 try to get a groups_id.
+				// why ask if $groupID === -1 when we did not change it since it was set it in line 281?
 				if ($groupID === -1) {
+					// check here if groupname is a valid name, sometimes nzbs contains shorted groupnames like: a.b.something
+					$groupN = Groups::isValidName($group);
+					if($groupN !== false) $group = $groupN;
+					
 					if (array_key_exists($group, $this->allGroups)) {
 						$groupID = $this->allGroups[$group];
-						if (!$groupName) {
-							$groupName = $group;
-						}
+						if (!$groupName) $groupName = $group;
 					} else {
-						$group = Groups::isValidName($group);
 						if ($group !== false) {
+							$group = $groupN;
 							/*$groupID = $this->groups->add([
 								'name' => $group,
 								'description' => 'Added by NZBimport script.',

--- a/nzedb/NZBImport.php
+++ b/nzedb/NZBImport.php
@@ -317,6 +317,7 @@ class NZBImport
 						$groupID = $this->allGroups[$group];
 						if (!$groupName) $groupName = $group;
 					} else {
+						$group = Groups::isValidName($group);
 						if ($group !== false) {
 							/*$groupID = $this->groups->add([
 								'name' => $group,

--- a/nzedb/NZBImport.php
+++ b/nzedb/NZBImport.php
@@ -311,7 +311,6 @@ class NZBImport
 						if (!$groupName) $groupName = $group;
 					} else {
 						if ($group !== false) {
-							$group = $groupN;
 							/*$groupID = $this->groups->add([
 								'name' => $group,
 								'description' => 'Added by NZBimport script.',

--- a/nzedb/NZBImport.php
+++ b/nzedb/NZBImport.php
@@ -297,7 +297,7 @@ class NZBImport
 			// Get the group names, groups_id, check if it's blacklisted.
 			$groupArr = [];
 			foreach ($file->groups->group as $group) {
-				$group = (string)$group;
+				$group = strtolower($group);
 
 				// If groups_id is -1 try to get a groups_id.
 				// why ask if $groupID === -1 when we did not change it since it was set it in line 281?

--- a/nzedb/NZBImport.php
+++ b/nzedb/NZBImport.php
@@ -302,9 +302,16 @@ class NZBImport
 				// If groups_id is -1 try to get a groups_id.
 				// why ask if $groupID === -1 when we did not change it since it was set it in line 281?
 				if ($groupID === -1) {
-					// check here if groupname is a valid name, sometimes nzbs contains shorted groupnames like: a.b.something
-					$groupN = Groups::isValidName($group);
-					if($groupN !== false) $group = $groupN;
+                                        // test if group is a shortname
+                                        // $testgroup = "a.b.something";
+                                        if(preg_match("/^[a-zA-Z0-9]\.[a-zA-Z0-9]\./",$group)) {
+                                                echo "group $group is a shortname\n";
+                                                $groupN = Groups::isValidName($group);
+                                                if($groupN !== false){
+                                                        $group = (string)$groupN;
+                                                        echo "set new group, groupN = $groupN";
+                                                        }
+                                        }
 					
 					if (array_key_exists($group, $this->allGroups)) {
 						$groupID = $this->allGroups[$group];


### PR DESCRIPTION
Update NZBimport.php: fix group shortnames

sometimes nzbs contain shorted group names like: a.b.something and import script fails (script dies) without any error message because it tried to create the shortname group which often already exists as fullname and it dies right on "$groupID->save()"

steps to recall the bug:
create a NZB
add meta data group: a.b.something
add the group with fullname "alt.binaries.something" to nzedb
import the nzb from cli: "php /var/www/nZEDb/misc/testing/nzb-import.php /path/ true true true 10"
import dies without an error or final message and no debugs shown.
