### PR TITLE
Update profileedit.tpl

### DIFF
--- a/www/themes/Charisma/templates/profileedit.tpl
+++ b/www/themes/Charisma/templates/profileedit.tpl
@@ -37,6 +37,18 @@
 																<strong>Profile</strong></td>
 														</tr>
 														<tr>
+                                                                                                                         <th width="200">First Name</th>
+                                                                                                                        <td><input id="firstname" class="form-control" name="firstname"
+                                                                                                                                           type="text"
+                                                                                                                                           value="{$user.firstname}"></td>
+                                                                                                                </tr>
+                                                                                                                <tr>
+                                                                                                                         <th width="200">Last Name</th>
+                                                                                                                        <td><input id="lastname" class="form-control" name="lastname"
+                                                                                                                                           type="text"
+                                                                                                                                           value="{$user.lastname}"></td>
+                                                                                                                </tr>
+														<tr>
 															<th width="200">E-Mail</th>
 															<td><input id="email" class="form-control" name="email"
 																	   type="text"


### PR DESCRIPTION
Add First / Last name field to profile edit

Addresses issue #.

Currently, if you save your profile in charisma, it will overwrite your First/Last name to be blank.

Changes made by this pull request.
- Fixes losing First / Last name on profile edit