### PR TITLE
Added a substring call to avoid the xref column truncate errors

### DIFF
--- a/nzedb/Binaries.php
+++ b/nzedb/Binaries.php
@@ -938,7 +938,7 @@ class Binaries
 						$timestamp = $now;
 					}
 
-					$xref = ($this->multiGroup === true ? sprintf('xref = CONCAT(xref, "\\n"%s ),', $this->_pdo->escapeString(substr($this->header['Xref'], 2, 255))) : '');
+					$xref = ($this->multiGroup === true ? sprintf('xref = SUBSTRING(CONCAT(xref, "\\n"%s ), 1, 4096),', $this->_pdo->escapeString(substr($this->header['Xref'], 2, 255))) : '');
 
 					$collectionID = $this->_pdo->queryInsert(
 						sprintf("


### PR DESCRIPTION
Addresses issue #2653.

Changes made by this pull request.
- Wrapped xref column concatenation with a substring call to limit column value length.
