### PR TITLE
POST preinfo does not need to unserialize classes

### DIFF
--- a/www/pages/preinfo.php
+++ b/www/pages/preinfo.php
@@ -291,7 +291,7 @@ if (isset($_GET['type'])) {
 	}
 } else if (isset($_POST['data'])) {
 
-	$reqData = @unserialize($_POST['data']);
+	$reqData = @unserialize($_POST['data'], ['allowed_classes' => false]);
 	if ($reqData !== false && is_array($reqData) && isset($reqData[0]['ident'])) {
 		$pdo = new DB;
 		$preData = [];


### PR DESCRIPTION
Addresses issue https://gitlab.com/cruatta/nzedb-pwn

Changes made by this pull request.
- POST /preinfo.php allows object deserialization, which does not seem to be required by this endpoint, According to the docs, it accepts an array with primitive types in it. I think it's safer to remove class deserialization than to keep it.

@niel 